### PR TITLE
Feat/hotspring api call

### DIFF
--- a/src/app/hotspringList/page.tsx
+++ b/src/app/hotspringList/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useState } from "react";
+import { useGetHotspringBySidoQuery } from "../lib/hotspring/hotspringApi";
+
+const HotspringListPage = () => {
+  const [selectedSido, setSelectedSido] = useState("서울특별시");
+  const { data, error } = useGetHotspringBySidoQuery(selectedSido);
+  const options = [
+    "서울특별시",
+    "부산광역시",
+    "대구광역시",
+    "인천광역시",
+    "광주광역시",
+    "대전광역시",
+    "울산광역시",
+    "세종특별자치시",
+    "경기도",
+    "강원도",
+    "충청북도",
+    "충청남도",
+    "전라북도",
+    "전라남도",
+    "경상북도",
+    "경상남도",
+    "제주특별자치도",
+  ];
+  return (
+    <div>
+      <select
+        value={selectedSido}
+        onChange={(e) => setSelectedSido(e.target.value)}
+      >
+        {options.map((sido) => (
+          <option key={sido} value={sido}>
+            {sido}
+          </option>
+        ))}
+      </select>
+      <ul>
+        {data?.map((spring, idx) => (
+          <li key={idx}>
+            {spring.properties.uname} ({spring.properties.sido_name}{" "}
+            {spring.properties.sigg_name})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default HotspringListPage;

--- a/src/app/hotspringList/page.tsx
+++ b/src/app/hotspringList/page.tsx
@@ -3,35 +3,40 @@
 import React, { useState } from "react";
 import { useGetHotspringBySidoQuery } from "../lib/hotspring/hotspringApi";
 
+const sidoCenters: Record<string, { lat: number; lng: number }> = {
+"서울특별시": { lat: 37.5665, lng: 126.9780 },
+"부산광역시": { lat: 35.1796, lng: 129.0756 },
+"대구광역시": { lat: 35.8714, lng: 128.6014 },
+"인천광역시": { lat: 37.4563, lng: 126.7052 },
+"광주광역시": { lat: 35.1595, lng: 126.8526 },
+"대전광역시": { lat: 36.3504, lng: 127.3845 },
+"울산광역시": { lat: 35.5384, lng: 129.3114 },
+"세종특별자치시": { lat: 36.4801, lng: 127.2890 },
+"경기도": { lat: 37.4138, lng: 127.5183 },
+"강원도": { lat: 37.8228, lng: 128.1555 },
+"충청북도": { lat: 36.6357, lng: 127.4917 },
+"충청남도": { lat: 36.5184, lng: 126.8000 },
+"전라북도": { lat: 35.7167, lng: 127.1442 },
+"전라남도": { lat: 34.8161, lng: 126.4630 },
+"경상북도": { lat: 36.4919, lng: 128.8889 },
+"경상남도": { lat: 35.4606, lng: 128.2132 },
+"제주특별자치도": { lat: 33.4996, lng: 126.5312 },
+};
+
 const HotspringListPage = () => {
   const [selectedSido, setSelectedSido] = useState("서울특별시");
-  const { data, error } = useGetHotspringBySidoQuery(selectedSido);
-  const options = [
-    "서울특별시",
-    "부산광역시",
-    "대구광역시",
-    "인천광역시",
-    "광주광역시",
-    "대전광역시",
-    "울산광역시",
-    "세종특별자치시",
-    "경기도",
-    "강원도",
-    "충청북도",
-    "충청남도",
-    "전라북도",
-    "전라남도",
-    "경상북도",
-    "경상남도",
-    "제주특별자치도",
-  ];
+  const coordinates = sidoCenters[selectedSido];
+  const { data, error } = useGetHotspringBySidoQuery(coordinates);
+
+  console.log("HotspringListPage data:", data);
+
   return (
     <div>
       <select
         value={selectedSido}
         onChange={(e) => setSelectedSido(e.target.value)}
       >
-        {options.map((sido) => (
+        {Object.keys(sidoCenters).map((sido) => (
           <option key={sido} value={sido}>
             {sido}
           </option>

--- a/src/app/hotspringList/page.tsx
+++ b/src/app/hotspringList/page.tsx
@@ -3,34 +3,31 @@
 import React, { useState } from "react";
 import { useGetHotspringBySidoQuery } from "../lib/hotspring/hotspringApi";
 
-const sidoCenters: Record<string, { lat: number; lng: number }> = {
-  서울특별시: { lng: 126.95966555678402, lat: 37.53298542326604 },
-};
 
 const HotspringListPage = () => {
   const [selectedSido, setSelectedSido] = useState("서울특별시");
-  const coordinates = sidoCenters[selectedSido];
-  const { data, error } = useGetHotspringBySidoQuery(coordinates);
+  const { data, error } = useGetHotspringBySidoQuery();
 
   console.log("HotspringListPage data:", data);
 
   return (
     <div>
-      <select
+      {/* <select
         value={selectedSido}
         onChange={(e) => setSelectedSido(e.target.value)}
       >
-        {Object.keys(sidoCenters).map((sido) => (
+        {Object.keys().map((sido) => (
           <option key={sido} value={sido}>
             {sido}
           </option>
         ))}
-      </select>
+      </select> */}
       <ul>
         {data?.map((spring, idx) => (
           <li key={idx}>
             {spring.properties.uname} ({spring.properties.sido_name}{" "}
             {spring.properties.sigg_name})
+            {spring.properties.remark}
           </li>
         ))}
       </ul>

--- a/src/app/hotspringList/page.tsx
+++ b/src/app/hotspringList/page.tsx
@@ -4,23 +4,7 @@ import React, { useState } from "react";
 import { useGetHotspringBySidoQuery } from "../lib/hotspring/hotspringApi";
 
 const sidoCenters: Record<string, { lat: number; lng: number }> = {
-"서울특별시": { lat: 37.5665, lng: 126.9780 },
-"부산광역시": { lat: 35.1796, lng: 129.0756 },
-"대구광역시": { lat: 35.8714, lng: 128.6014 },
-"인천광역시": { lat: 37.4563, lng: 126.7052 },
-"광주광역시": { lat: 35.1595, lng: 126.8526 },
-"대전광역시": { lat: 36.3504, lng: 127.3845 },
-"울산광역시": { lat: 35.5384, lng: 129.3114 },
-"세종특별자치시": { lat: 36.4801, lng: 127.2890 },
-"경기도": { lat: 37.4138, lng: 127.5183 },
-"강원도": { lat: 37.8228, lng: 128.1555 },
-"충청북도": { lat: 36.6357, lng: 127.4917 },
-"충청남도": { lat: 36.5184, lng: 126.8000 },
-"전라북도": { lat: 35.7167, lng: 127.1442 },
-"전라남도": { lat: 34.8161, lng: 126.4630 },
-"경상북도": { lat: 36.4919, lng: 128.8889 },
-"경상남도": { lat: 35.4606, lng: 128.2132 },
-"제주특별자치도": { lat: 33.4996, lng: 126.5312 },
+  서울특별시: { lng: 126.95966555678402, lat: 37.53298542326604 },
 };
 
 const HotspringListPage = () => {

--- a/src/app/lib/hotspring/hotspringApi.ts
+++ b/src/app/lib/hotspring/hotspringApi.ts
@@ -1,0 +1,15 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const hotspringApi = createApi({
+  reducerPath: "hotspringApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: `${process.env.NEXT_PUBLIC_API_URL}/v1/hotspring`,
+  }),
+  endpoints: (builder) => ({
+    getHotspringBySido: builder.query<any[], string>({
+      query: (sido) => `?sido=${encodeURIComponent(sido)}`,
+    }),
+  }),
+});
+
+export const { useGetHotspringBySidoQuery } = hotspringApi;

--- a/src/app/lib/hotspring/hotspringApi.ts
+++ b/src/app/lib/hotspring/hotspringApi.ts
@@ -6,8 +6,8 @@ export const hotspringApi = createApi({
     baseUrl: `${process.env.NEXT_PUBLIC_API_URL}/v1/hotspring`,
   }),
   endpoints: (builder) => ({
-    getHotspringBySido: builder.query<any[], {lat:number; lng:number}>({
-      query: ({ lat, lng }) => `?lat=${lat}&lng=${lng}`,
+    getHotspringBySido: builder.query({
+      query: () => '/'
     }),
   }),
 });

--- a/src/app/lib/hotspring/hotspringApi.ts
+++ b/src/app/lib/hotspring/hotspringApi.ts
@@ -6,8 +6,8 @@ export const hotspringApi = createApi({
     baseUrl: `${process.env.NEXT_PUBLIC_API_URL}/v1/hotspring`,
   }),
   endpoints: (builder) => ({
-    getHotspringBySido: builder.query<any[], string>({
-      query: (sido) => `?sido=${encodeURIComponent(sido)}`,
+    getHotspringBySido: builder.query<any[], {lat:number; lng:number}>({
+      query: ({ lat, lng }) => `?lat=${lat}&lng=${lng}`,
     }),
   }),
 });

--- a/src/app/lib/store/store.ts
+++ b/src/app/lib/store/store.ts
@@ -2,15 +2,17 @@ import { configureStore } from "@reduxjs/toolkit";
 import { authApi } from "../auth/authApi";
 import authReducer from "../auth/authSlice";
 import resetPasswordReducer from "../reset-password/resetPasswordSlice";
+import { hotspringApi } from "../hotspring/hotspringApi";
 
 export const store = configureStore({
     reducer: {
         auth:authReducer,
         resetPassword: resetPasswordReducer,
         [authApi.reducerPath]: authApi.reducer,
+        [hotspringApi.reducerPath] : hotspringApi.reducer,
     },
     middleware: (getDefaultMiddleware) =>
-        getDefaultMiddleware().concat(authApi.middleware),
+        getDefaultMiddleware().concat(authApi.middleware, hotspringApi.middleware)
 })
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
# Pull Request

## Description  
- Implemented backend API endpoint to fetch hot spring protection zone data from VWorld OpenAPI (LT_C_UJ401 layer).
- Parsed and returned structured JSON containing 온천명, 시도명, 시군구명, 기타 정보(remark)
- Created page.tsx on the frontend to display a list of 온천 보호구역 with region and remark data.

## Why  
- This feature enables users to view a structured list of 온천공보호구역 across Korea.
- Integrates national public spatial data using VWorld’s data API.
- Serves as a foundational implementation for future regional filtering or map visualization features.

## Testing  
- Ran the backend server locally and confirmed the API response from VWorld is parsed and structured correctly.
- Called the endpoint from the frontend using RTK Query (useGetHotspringBySidoQuery).
- Verified the hot spring list renders correctly on the page with name, location, and remark data displayed.
- Checked console output for error handling and validated response structure.

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [x] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
