### PR TITLE
Feat/report review

### DIFF
--- a/src/app/lodge/[lodgeId]/page.tsx
+++ b/src/app/lodge/[lodgeId]/page.tsx
@@ -228,9 +228,10 @@ const LodgeDetailPage = () => {
     }
 
     const typesReviews = reviews as Review[];
-    const totalReviews = typesReviews.length;
+    const visibleReviews = typesReviews.filter(r => !r.isHidden);
+    const totalReviews = visibleReviews.length;
     const averageRating = (
-      typesReviews.reduce((sum, review) => sum + review.rating, 0) /
+      visibleReviews.reduce((sum, review) => sum + review.rating, 0) /
       totalReviews
     ).toFixed(1);
 

--- a/src/components/ui/ReviewCard.tsx
+++ b/src/components/ui/ReviewCard.tsx
@@ -113,39 +113,47 @@ const ReviewCard = ({
         )}
       </div>
 
-      <p>{review.rating} / 5</p>
-
-      {isEditing && isOwner ? (
-        <div className="mt-2 flex flex-col gap-2">
-          <input
-            type="text"
-            className="border rounded px-3 py-2 w-full"
-            value={editingComment}
-            onChange={(e) => setEditingComment(e.target.value)}
-          />
-          <input
-            type="number"
-            className="border rounded px-3 py-2 w-full"
-            value={editingRating ?? ""}
-            onChange={(e) => setEditingRating(Number(e.target.value))}
-          />
-          <div className="flex gap-2">
-            <button
-              onClick={() => saveEdit(review)}
-              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            >
-              Save
-            </button>
-            <button
-              onClick={cancelEditing}
-              className="px-4 py-2 border rounded hover:bg-gray-100"
-            >
-              Cancel
-            </button>
-          </div>
+      {review.isHidden ? (
+        <div className="text-gray-400 italic mt-2">
+          관리자에 의해 가려진 댓글입니다.
         </div>
       ) : (
-        <p className="mt-2 text-gray-700">{review.comment}</p>
+        <>
+          {!isEditing && <p>{review.rating} / 5</p>}
+
+          {isEditing && isOwner ? (
+            <div className="mt-2 flex flex-col gap-2">
+              <input
+                type="text"
+                className="border rounded px-3 py-2 w-full"
+                value={editingComment}
+                onChange={(e) => setEditingComment(e.target.value)}
+              />
+              <input
+                type="number"
+                className="border rounded px-3 py-2 w-full"
+                value={editingRating ?? ""}
+                onChange={(e) => setEditingRating(Number(e.target.value))}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => saveEdit(review)}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                >
+                  Save
+                </button>
+                <button
+                  onClick={cancelEditing}
+                  className="px-4 py-2 border rounded hover:bg-gray-100"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-2 text-gray-700">{review.comment}</p>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/types/reivew.ts
+++ b/src/types/reivew.ts
@@ -5,6 +5,7 @@ export interface Review {
   rating: number;
   comment?: string | null;
   createdAt: string;
+  isHidden: boolean;
   lodge: LodgeSummary;
   user?:{
     id: number;


### PR DESCRIPTION
# Pull Request

## Description  
- Refactored `ReviewCard.tsx` to handle **hidden** reviews (`isHidden` flag).
- When a review is marked as hidden by an admin, the card now displays:
  > "관리자에 의해 가려진 댓글입니다."
  instead of the rating or comment.
- Prevents showing ratings/comments for hidden reviews in the UI.
- Updated average rating calculation logic (elsewhere) to **exclude** hidden reviews so they don't affect the displayed average score.


## Why  
- To support moderation tools: admins can hide inappropriate or off-topic reviews without deleting them.
- Improves transparency by letting users see that a comment was hidden (instead of silently disappearing).
- Ensures average ratings remain accurate and only include *visible* reviews.


## Testing  
- Ran the app locally.
- Checked multiple reviews with `isHidden: true` and verified:
  - Card renders the "hidden by admin" message.
  - No rating or comment text is shown.
- Verified averageRating calculation excludes hidden reviews.
- Tested toggling hide/unhide from the admin dashboard to ensure UI updates properly.


## Linked Issues  
Fixes #32 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
