### PR TITLE
Feat/report review

### DIFF
--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -84,7 +84,13 @@ export default function ReportReviewsPage() {
               </button>
               <button 
                 className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
-                onClick={() => handleDeleteReview(report.review.id)}
+                onClick={() => {
+                  if(report?.review?.id !== null) {
+                  handleDeleteReview(report.review.id)
+                } else {
+                  alert("리뷰 ID가 없습니다.");
+                }
+              }}
               >
                 리뷰 삭제
               </button>

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -4,10 +4,11 @@ import React, { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import {
   deleteReportedReview,
+  deleteReviewOnly,
   fetchReports,
   hideReportReview,
 } from "@/lib/admin/reports/reportsThunk";
-import { useDeleteReviewMutation } from "@/lib/review/reviewApi";
+// import { useDeleteReviewMutation } from "@/lib/review/reviewApi";
 
 export default function ReportReviewsPage() {
   const dispatch = useAppDispatch();
@@ -15,7 +16,7 @@ export default function ReportReviewsPage() {
     (state) => state["admin/reports"]
   );
 
-  const [deleteReview] = useDeleteReviewMutation()
+  // const [deleteReview] = useDeleteReviewMutation()
 
   useEffect(() => {
     dispatch(fetchReports());
@@ -33,7 +34,7 @@ export default function ReportReviewsPage() {
 
   const handleDeleteReview = async (reviewId: number) => {
     try {
-      await deleteReview(reviewId).unwrap();
+      dispatch(deleteReviewOnly(reviewId));
       alert("리뷰가 성공적으로 삭제되었습니다.");
       dispatch(fetchReports());
     } catch (error) {

--- a/src/app/profile/reviews/page.tsx
+++ b/src/app/profile/reviews/page.tsx
@@ -139,6 +139,9 @@ const ReviewsPage = () => {
                 <div>
                   <span className="font-semibold">{review.user?.nickname}</span>
                   <p className="text-yellow-500">{review.rating} / 5</p>
+                  {review.isHidden && (
+                    <p className="text-white bg-red-500 px-2 py-1 rounded-sm">가려진 리뷰입니다.</p>
+                  )}
                 </div>
 
                 <div className="relative">

--- a/src/lib/admin/reports/reportsSlice.ts
+++ b/src/lib/admin/reports/reportsSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
   deleteReportedReview,
+  deleteReviewOnly,
   fetchReports,
   hideReportReview,
   ReportReviews,
@@ -88,6 +89,19 @@ const reportsSlice = createSlice({
         }
       )
       .addCase(hideReportReview.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      })
+      .addCase(deleteReviewOnly.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(deleteReviewOnly.fulfilled, (state, action) => {
+        state.state = "succeeded";
+        const deletedId = action.payload.reviewId;
+        state.list = state.list.filter((report) => report.review.id !== deletedId);
+      })
+      .addCase(deleteReviewOnly.rejected, (state, action) => {
         state.state = "failed";
         state.error = action.payload as string;
       });

--- a/src/lib/admin/reports/reportsThunk.ts
+++ b/src/lib/admin/reports/reportsThunk.ts
@@ -69,7 +69,7 @@ export const deleteReportedReview = createAsyncThunk<
     try {
       const token = getState().auth.accessToken;
       const res = await axios.delete(
-        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/reports/review/${reviewId}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/reports/report-only/${reviewId}`,
         {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -89,11 +89,11 @@ export const deleteReportedReview = createAsyncThunk<
 
 export const hideReportReview = createAsyncThunk<
   { message: string; updated: { id: number; isHidden: boolean } },
-  {reviewId: number; isHidden: boolean},
+  { reviewId: number; isHidden: boolean },
   { rejectValue: string; state: RootState }
 >(
   "admin/hideReportReview",
-  async ({reviewId, isHidden}, { dispatch, rejectWithValue, getState }) => {
+  async ({ reviewId, isHidden }, { dispatch, rejectWithValue, getState }) => {
     try {
       const token = getState().auth.accessToken;
       const res = await axios.patch(
@@ -119,6 +119,34 @@ export const hideReportReview = createAsyncThunk<
         dispatch(logout());
       }
       return rejectWithValue("Failed to hide reported review");
+    }
+  }
+);
+
+export const deleteReviewOnly = createAsyncThunk<
+  { message: string; reviewId: number },
+  number,
+  { rejectValue: string; state: RootState }
+>(
+  "admin/deleteReviewOnly",
+  async (reviewId, { dispatch, rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const res = await axios.delete(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/reports/review-only/${reviewId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data as { message: string; reviewId: number };
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to delete review");
     }
   }
 );


### PR DESCRIPTION
# Pull Request

## Description  
- Refactored the admin/reports/page.tsx component to support new delete options:
  - Added separate buttons and handlers for deleting only the report entry or only the review entry.
  - Integrated new Redux thunks: deleteReportedReview and deleteReviewOnly.
- Improved UX by showing clearer actions in the admin dashboard:
  - "신고 해결" now deletes only the report from the listing.
  - "리뷰 삭제" now deletes the review itself even if reports exist.
- Updated UI button logic to guard against invalid IDs.

## Why  
- Matched the frontend admin UI to the updated backend endpoints that allow more granular moderation.
- Prevented crashes and bad requests by validating review IDs before sending deletion requests.
- Made admin review moderation clearer and easier to use by splitting delete actions.

## Testing  
- Ran the Next.js app locally.
- Loaded the /admin/reports page and verified:
  - Reports fetched and displayed correctly.
  - "신고 해결" button removed only the report from the listing without deleting the review.
  - "리뷰 삭제" button removed the review and automatically removed associated reports.
- Confirmed no 500 errors on invalid deletes.
- Checked updated state after performing each action.

## Linked Issues  
Fixes #33 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
