### PR TITLE
Feat/reservation

### DIFF
--- a/src/app/reservation/confirm/page.tsx
+++ b/src/app/reservation/confirm/page.tsx
@@ -67,24 +67,29 @@ const ReservationConfirmPage = () => {
   }, [widgets]);
 
   useEffect(() => {
-    const pending = JSON.parse(
-      localStorage.getItem("pendingReservation") || "[]"
-    );
+    // const pending = JSON.parse(
+    //   localStorage.getItem("pendingReservation") || "[]"
+    // );
 
-    dispatch(createReservation(pending));
+    // dispatch(createReservation(pending));
   }, []);
 
   const handleTossPayment = async () => {
     if (!widgets || !ready) return;
 
     try {
+      const pending = JSON.parse(localStorage.getItem("pendingReservation") || "[]");
+      const created = await dispatch(createReservation(pending)).unwrap();
+
+      const reservationId = created.id
+      
       const paymentResult = await widgets.requestPayment({
         orderId: `reservation-${Date.now()}`,
         orderName: "숙소 예약",
         customerName: `${firstName} ${lastName}`,
         customerEmail: email,
         customerMobilePhone: phoneNumber,
-        successUrl: `${window.location.origin}/reservation/success?`,
+        successUrl: `${window.location.origin}/reservation/success?reservationId=${reservationId}`,
         failUrl: `${window.location.origin}/reservation/fail?lodgeId=${lodgeId}`,
       });
 

--- a/src/app/reservation/success/page.tsx
+++ b/src/app/reservation/success/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import { confirmReservation } from "@/lib/reservation/reservationThunk";
+import { useAppDispatch } from "@/lib/store/hooks";
 import { getNights } from "@/utils/getNights";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
 
 const ReservationSuccessPage = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [pending, setPending] = useState<any>(null);
+
+  const reservationId = searchParams.get("reservationId")
+
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     const data = localStorage.getItem("pendingReservation") || "{}";
@@ -14,6 +21,12 @@ const ReservationSuccessPage = () => {
       setPending(JSON.parse(data));
     }
   }, []);
+
+  useEffect(() => {
+    if(reservationId) {
+      dispatch(confirmReservation({ reservationId:Number(reservationId) }))
+    }
+  },[reservationId])
 
   if (!pending) {
     return <div>Loading...</div>;


### PR DESCRIPTION
# Pull Request

## Description  
- Fixed issue where reservation was created twice in DB.
- Refactored frontend flow to create reservation only once, right before payment.
- Implemented logic to call confirmReservation API after payment succeeds, changing reservation status from PENDING to CONFIRMED.

## Why  
- Previously, navigating to the payment page would immediately create a PENDING reservation in the database before payment was made.
- This led to duplicate reservations and abandoned PENDING records.
- Also, reservation status remained PENDING even after successful payment because there was no confirm call.
- These changes ensure:
  - Reservation is created exactly once, only after user starts payment.
  - Reservation status is correctly updated to CONFIRMED when payment succeeds.

## Testing  
- Ran the app locally.
- Verified that no reservation is created when first entering the payment page.
- Clicked the payment button to trigger reservation creation and payment.
- Checked DB to confirm only one reservation was created.
- Completed payment and confirmed reservation status updated to CONFIRMED.
- Tested failure scenario to ensure no extra reservation is left in PENDING unnecessarily.

## Linked Issues  
Fixes #24 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
