### PR TITLE
Feat/reservation

### DIFF
--- a/src/lib/reservation/reservationSlice.ts
+++ b/src/lib/reservation/reservationSlice.ts
@@ -1,6 +1,10 @@
 import { Reservation } from "@/types/reservation";
 import { createSlice } from "@reduxjs/toolkit";
-import { createReservation, fetchReservation } from "./reservationThunk";
+import {
+  cancelReservation,
+  createReservation,
+  fetchReservation,
+} from "./reservationThunk";
 
 interface ReservationState {
   list: Reservation[];
@@ -42,6 +46,12 @@ const reservationSlice = createSlice({
           state.list[index] = action.payload;
         } else {
           state.list.unshift(action.payload);
+        }
+      })
+      .addCase(cancelReservation.fulfilled, (state, action) => {
+        const index = state.list.findIndex((r) => r.id === action.payload.id);
+        if (index !== -1) {
+          state.list[index] = action.payload;
         }
       });
   },

--- a/src/lib/reservation/reservationThunk.ts
+++ b/src/lib/reservation/reservationThunk.ts
@@ -92,3 +92,29 @@ export const confirmReservation = createAsyncThunk<
     }
   }
 );
+
+export const cancelReservation = createAsyncThunk<
+  Reservation,
+  { reservationId: number; cancelReason: string },
+  { rejectValue: string; state: RootState }
+>(
+  "reservation/cancelReservation",
+  async ({ reservationId, cancelReason }, { getState, rejectWithValue }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const response = await axios.patch(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/reservation/${reservationId}/cancel`,
+        { cancelReason },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return response.data as Reservation;
+    } catch (error) {
+      return rejectWithValue("Failed to cancel reservation");
+    }
+  }
+);


### PR DESCRIPTION
# Pull Request

## Description  
- Added "예약 취소" button in reservation detail modal on frontend
- Integrated cancelReservation API call to handle user-initiated reservation cancellations
- Implemented confirmation modal with refund policy agreement before cancellation
- Updated reservation list to refresh after successful cancellation


## Why  
This improves user experience by allowing users to cancel their reservations directly from their reservation list page. It also ensures that cancellation is clear and deliberate by presenting refund policy details before confirming.


## Testing  
- Ran the app locally
- Navigated to the reservation list page
- Opened reservation detail modal
- Verified "예약 취소" button appears only for CONFIRMED reservations
- Clicked to view and agree to refund policy
- Cancelled reservation and confirmed that reservation list updated correctly
- Verified backend updated reservation status and inventory


## Linked Issues  
Fixes #48 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [x] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
