### PR TITLE
Feat/admin

### DIFF
--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import {
   updateUserRole,
@@ -12,6 +12,9 @@ import {
 import { AppDispatch, RootState } from "@/lib/store/store";
 
 export default function UserDetailPage() {
+  const [reservationPage, setReservationPage] = useState(1);
+  const [reviewPage, setReviewPage] = useState(1);
+
   const { userId } = useParams<{ userId: string }>();
   const dispatch: AppDispatch = useAppDispatch();
   const id = Number(userId);
@@ -20,14 +23,22 @@ export default function UserDetailPage() {
     (state: RootState) => state["admin/user"]
   );
 
+  const { reservationTotal, reservationLimit, reviewTotal, reviewLimit } =
+    useAppSelector((state: RootState) => state["admin/user"]);
+
+  const totalReservationPages = Math.ceil(reservationTotal / reservationLimit);
+  const totalReviewPages = Math.ceil(reviewTotal / reviewLimit);
+
   const user = list.find((u) => u.id === id);
 
   useEffect(() => {
     if (user) {
-      dispatch(fetchUserReservations(id));
-      dispatch(fetchUserReviews(id));
+      dispatch(
+        fetchUserReservations({ userId: id, page: reservationPage, limit: 10 })
+      );
+      dispatch(fetchUserReviews({ userId: id, page: reviewPage, limit: 10 }));
     }
-  }, [dispatch, id, user]);
+  }, [dispatch, id, user, reservationPage, reviewPage]);
 
   const handleRoleChange = (role: "USER" | "ADMIN") => {
     dispatch(updateUserRole({ userId: id, role }));
@@ -122,6 +133,22 @@ export default function UserDetailPage() {
                 <p className="text-gray-500 text-sm">예약ID: {r.id}</p>
               </div>
             ))}
+            <div className="flex justify-center mt-4 space-x-2">
+              <button
+                disabled={reservationPage === 1}
+                onClick={() => setReservationPage(reservationPage - 1)}
+                className="px-3 py-1 rounded border bg-gray-100 hover:bg-gray-200 disabled:opacity-50"
+              >
+                이전
+              </button>
+              <button
+                disabled={reservationPage >= totalReservationPages}
+                onClick={() => setReservationPage(reservationPage + 1)}
+                className="px-3 py-1 rounded border bg-gray-100 hover:bg-gray-200 disabled:opacity-50"
+              >
+                다음
+              </button>
+            </div>
           </div>
         )}
       </div>
@@ -153,6 +180,22 @@ export default function UserDetailPage() {
                 </p>
               </div>
             ))}
+            <div className="flex justify-center mt-4 space-x-2">
+              <button
+                disabled={reviewPage === 1}
+                onClick={() => setReviewPage(reviewPage - 1)}
+                className="px-3 py-1 rounded border bg-gray-100 hover:bg-gray-200 disabled:opacity-50"
+              >
+                이전
+              </button>
+              <button
+                disabled={reviewPage >= totalReviewPages}
+                onClick={() => setReviewPage(reviewPage + 1)}
+                className="px-3 py-1 rounded border bg-gray-100 hover:bg-gray-200 disabled:opacity-50"
+              >
+                다음
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import React, { useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
+import {
+  updateUserRole,
+  deleteUser,
+  fetchUserReservations,
+  fetchUserReviews,
+} from "@/lib/admin/user/adminUserThunk";
+import { AppDispatch, RootState } from "@/lib/store/store";
+
+export default function UserDetailPage() {
+  const { userId } = useParams<{ userId: string }>();
+  const dispatch: AppDispatch = useAppDispatch();
+  const id = Number(userId);
+
+  const { list, reservations, reviews, state } = useAppSelector(
+    (state: RootState) => state["admin/user"]
+  );
+
+  const user = list.find((u) => u.id === id);
+
+  useEffect(() => {
+    if (user) {
+      dispatch(fetchUserReservations(id));
+      dispatch(fetchUserReviews(id));
+    }
+  }, [dispatch, id, user]);
+
+  const handleRoleChange = (role: "USER" | "ADMIN") => {
+    dispatch(updateUserRole({ userId: id, role }));
+  };
+
+  const handleDelete = () => {
+    if (window.confirm("정말 이 사용자를 삭제하시겠습니까?")) {
+      dispatch(deleteUser(id));
+    }
+  };
+
+  if (!user) {
+    return <div className="p-6">유저 정보를 찾을 수 없습니다.</div>;
+  }
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">사용자 상세 관리</h1>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">기본 정보</h2>
+        <p>
+          <strong>ID:</strong> {user.id}
+        </p>
+        <p>
+          <strong>이메일:</strong> {user.email}
+        </p>
+        <p>
+          <strong>닉네임:</strong> {user.nickname}
+        </p>
+        <p>
+          <strong>가입일:</strong>{" "}
+          {new Date(user.createdAt).toLocaleDateString()}
+        </p>
+        <div className="mt-2">
+          <label className="mr-2">권한 변경:</label>
+          <select
+            value={user.role}
+            onChange={(e) =>
+              handleRoleChange(e.target.value as "USER" | "ADMIN")
+            }
+            className="border rounded px-2 py-1"
+          >
+            <option value="USER">USER</option>
+            <option value="ADMIN">ADMIN</option>
+          </select>
+        </div>
+        <button
+          onClick={handleDelete}
+          className="mt-4 bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+        >
+          삭제
+        </button>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-2">예약 내역</h2>
+        {state === "loading" && <p>불러오는 중...</p>}
+        {reservations.length === 0 && (
+          <p className="text-gray-500">예약이 없습니다.</p>
+        )}
+        {reservations.length > 0 && (
+          <ul className="list-disc pl-6">
+            {reservations.map((r) => (
+              <li key={r.id}>
+                {r.lodge?.name ?? "알 수 없는 숙소"} -{" "}
+                {new Date(r.checkIn).toLocaleDateString()}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">작성 리뷰</h2>
+        {state === "loading" && <p>불러오는 중...</p>}
+        {reviews.length === 0 && (
+          <p className="text-gray-500">작성한 리뷰가 없습니다.</p>
+        )}
+        {reviews.length > 0 && (
+          <ul className="list-disc pl-6">
+            {reviews.map((review) => (
+              <li key={review.id}>
+                <p>
+                  <strong>{review.rating} / 5</strong>
+                  <strong>리뷰 내용:</strong> {review.comment}
+                </p>
+                <p>
+                  <strong>숙소 이름:</strong>{" "}
+                  {review.lodge?.name ?? "알 수 없는 숙소"}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -44,86 +44,118 @@ export default function UserDetailPage() {
   }
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">사용자 상세 관리</h1>
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">
+        사용자 상세 관리
+      </h1>
 
-      <section className="mb-6">
-        <h2 className="text-xl font-semibold mb-2">기본 정보</h2>
-        <p>
-          <strong>ID:</strong> {user.id}
-        </p>
-        <p>
-          <strong>이메일:</strong> {user.email}
-        </p>
-        <p>
-          <strong>닉네임:</strong> {user.nickname}
-        </p>
-        <p>
-          <strong>가입일:</strong>{" "}
-          {new Date(user.createdAt).toLocaleDateString()}
-        </p>
-        <div className="mt-2">
-          <label className="mr-2">권한 변경:</label>
-          <select
-            value={user.role}
-            onChange={(e) =>
-              handleRoleChange(e.target.value as "USER" | "ADMIN")
-            }
-            className="border rounded px-2 py-1"
-          >
-            <option value="USER">USER</option>
-            <option value="ADMIN">ADMIN</option>
-          </select>
+      <div className="bg-white shadow rounded-lg p-6 mb-8">
+        <h2 className="text-xl font-semibold text-gray-700 mb-4 border-b pb-2">
+          기본 정보
+        </h2>
+        <div className="grid sm:grid-cols-2 gap-4 mb-4">
+          <div>
+            <p className="text-gray-600">
+              <strong>ID:</strong> {user.id}
+            </p>
+            <p className="text-gray-600">
+              <strong>이메일:</strong> {user.email}
+            </p>
+            <p className="text-gray-600">
+              <strong>닉네임:</strong> {user.nickname}
+            </p>
+            <p className="text-gray-600">
+              <strong>가입일:</strong>{" "}
+              {new Date(user.createdAt).toLocaleDateString()}
+            </p>
+          </div>
+          <div>
+            <label className="block mb-2 font-medium text-gray-700">
+              권한 변경:
+            </label>
+            <select
+              value={user.role}
+              onChange={(e) =>
+                handleRoleChange(e.target.value as "USER" | "ADMIN")
+              }
+              className="border rounded px-3 py-2 w-full"
+            >
+              <option value="USER">USER</option>
+              <option value="ADMIN">ADMIN</option>
+            </select>
+          </div>
         </div>
         <button
           onClick={handleDelete}
-          className="mt-4 bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+          className="mt-4 bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600 transition"
         >
           삭제
         </button>
-      </section>
+      </div>
 
-      <section className="mb-6">
-        <h2 className="text-xl font-semibold mb-2">예약 내역</h2>
-        {state === "loading" && <p>불러오는 중...</p>}
+      <div className="bg-white shadow rounded-lg p-6 mb-8">
+        <h2 className="text-xl font-semibold text-gray-700 mb-4 border-b pb-2">
+          예약 내역
+        </h2>
+        {state === "loading" && <p className="text-gray-500">불러오는 중...</p>}
         {reservations.length === 0 && (
           <p className="text-gray-500">예약이 없습니다.</p>
         )}
         {reservations.length > 0 && (
-          <ul className="list-disc pl-6">
+          <div className="space-y-4">
             {reservations.map((r) => (
-              <li key={r.id}>
-                {r.lodge?.name ?? "알 수 없는 숙소"} -{" "}
-                {new Date(r.checkIn).toLocaleDateString()}
-              </li>
+              <div
+                key={r.id}
+                className="border rounded p-4 hover:shadow transition"
+              >
+                <p>
+                  <strong>숙소:</strong> {r.lodge?.name ?? "알 수 없는 숙소"}
+                </p>
+                <p>
+                  <strong>체크인:</strong>{" "}
+                  {new Date(r.checkIn).toLocaleDateString()}
+                </p>
+                <p>
+                  <strong>체크아웃:</strong>{" "}
+                  {new Date(r.checkOut).toLocaleDateString()}
+                </p>
+                <p className="text-gray-500 text-sm">예약ID: {r.id}</p>
+              </div>
             ))}
-          </ul>
+          </div>
         )}
-      </section>
+      </div>
 
-      <section>
-        <h2 className="text-xl font-semibold mb-2">작성 리뷰</h2>
-        {state === "loading" && <p>불러오는 중...</p>}
+      <div className="bg-white shadow rounded-lg p-6">
+        <h2 className="text-xl font-semibold text-gray-700 mb-4 border-b pb-2">
+          작성 리뷰
+        </h2>
+        {state === "loading" && <p className="text-gray-500">불러오는 중...</p>}
         {reviews.length === 0 && (
           <p className="text-gray-500">작성한 리뷰가 없습니다.</p>
         )}
         {reviews.length > 0 && (
-          <ul className="list-disc pl-6">
+          <div className="space-y-4">
             {reviews.map((review) => (
-              <li key={review.id}>
-                <p>
-                  <strong>{review.rating} / 5</strong>
-                  <strong>리뷰 내용:</strong> {review.comment}
-                </p>
-                <p>
-                  <strong>숙소 이름:</strong>{" "}
+              <div
+                key={review.id}
+                className="border rounded p-4 hover:shadow transition"
+              >
+                <p className="font-medium text-gray-800">
+                  <strong>숙소:</strong>{" "}
                   {review.lodge?.name ?? "알 수 없는 숙소"}
                 </p>
-              </li>
+                <p>
+                  <strong>평점:</strong> {review.rating} / 5
+                </p>
+                <p className="mt-2 text-gray-700">
+                  <strong>리뷰 내용:</strong> {review.comment}
+                </p>
+              </div>
             ))}
-          </ul>
+          </div>
         )}
-      </section>
+      </div>
     </div>
   );
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -8,9 +8,11 @@ import {
   updateUserRole,
 } from "@/lib/admin/user/adminUserThunk";
 import { AppDispatch, RootState } from "@/lib/store/store";
+import { useRouter } from "next/navigation";
 
 export default function AdminUsersPage() {
   const dispatch: AppDispatch = useAppDispatch();
+  const router = useRouter();
 
   const { list, state, error } = useAppSelector(
     (state: RootState) => state["admin/user"]
@@ -50,27 +52,15 @@ export default function AdminUsersPage() {
           </thead>
           <tbody>
             {list.map((user) => (
-              <tr key={user.id} className="hover:bg-gray-50">
+              <tr
+                key={user.id}
+                className="hover:bg-gray-50 cursor-pointer"
+                onClick={() => router.push(`/admin/users/${user.id}`)}
+              >
                 <td className="p-2 border text-center">{user.id}</td>
                 <td className="p-2 border">{user.email}</td>
                 <td className="p-2 border">{user.nickname}</td>
-                <td className="p-2 border text-center">
-                  <select
-                    value={user.role}
-                    onChange={(e) =>
-                      dispatch(
-                        updateUserRole({
-                          userId: user.id,
-                          role: e.target.value as "USER" | "ADMIN",
-                        })
-                      )
-                    }
-                    className="border rounded px-2 py-1"
-                  >
-                    <option value="USER">USER</option>
-                    <option value="ADMIN">ADMIN</option>
-                  </select>
-                </td>
+                <td className="p-2 border text-center">{user.role}</td>
                 <td className="p-2 border text-center">
                   {new Date(user.createdAt).toLocaleDateString()}
                 </td>

--- a/src/lib/admin/user/adminUserSlice.ts
+++ b/src/lib/admin/user/adminUserSlice.ts
@@ -13,7 +13,13 @@ import { Review } from "@/types/reivew";
 interface UserState {
   list: User[];
   reservations: Reservation[];
+  reservationTotal: number;
+  reservationPage: number;
+  reservationLimit: number;
   reviews: Review[];
+  reviewTotal: number;
+  reviewPage: number;
+  reviewLimit: number;
   state: "idle" | "loading" | "succeeded" | "failed";
   error: string | null;
 }
@@ -21,7 +27,13 @@ interface UserState {
 const initialState: UserState = {
   list: [],
   reservations: [],
+  reservationTotal: 0,
+  reservationPage: 1,
+  reservationLimit: 10,
   reviews: [],
+  reviewTotal: 0,
+  reviewPage: 1,
+  reviewLimit: 10,
   state: "idle",
   error: null,
 };
@@ -89,10 +101,16 @@ const adminUserSlice = createSlice({
         state.error = action.payload as string;
       })
       .addCase(fetchUserReservations.fulfilled, (state, action) => {
-        state.reservations = action.payload;
+        state.reservations = action.payload.data;
+        state.reservationTotal = action.payload.total;
+        state.reservationPage = action.payload.page;
+        state.reservationLimit = action.payload.limit;
       })
       .addCase(fetchUserReviews.fulfilled, (state, action) => {
-        state.reviews = action.payload;
+        state.reviews = action.payload.data;
+        state.reviewTotal = action.payload.total;
+        state.reviewPage = action.payload.page;
+        state.reviewLimit = action.payload.limit;
       });
   },
 });

--- a/src/lib/admin/user/adminUserSlice.ts
+++ b/src/lib/admin/user/adminUserSlice.ts
@@ -2,18 +2,26 @@ import { createSlice } from "@reduxjs/toolkit";
 import {
   deleteUser,
   fetchAllUsers,
+  fetchUserReservations,
+  fetchUserReviews,
   updateUserRole,
   User,
 } from "./adminUserThunk";
+import { Reservation } from "@/types/reservation";
+import { Review } from "@/types/reivew";
 
 interface UserState {
   list: User[];
+  reservations: Reservation[];
+  reviews: Review[];
   state: "idle" | "loading" | "succeeded" | "failed";
   error: string | null;
 }
 
 const initialState: UserState = {
   list: [],
+  reservations: [],
+  reviews: [],
   state: "idle",
   error: null,
 };
@@ -79,6 +87,12 @@ const adminUserSlice = createSlice({
       .addCase(updateUserRole.rejected, (state, action) => {
         state.state = "failed";
         state.error = action.payload as string;
+      })
+      .addCase(fetchUserReservations.fulfilled, (state, action) => {
+        state.reservations = action.payload;
+      })
+      .addCase(fetchUserReviews.fulfilled, (state, action) => {
+        state.reviews = action.payload;
       });
   },
 });

--- a/src/lib/admin/user/adminUserThunk.ts
+++ b/src/lib/admin/user/adminUserThunk.ts
@@ -3,6 +3,8 @@ import { RootState } from "../../store/store";
 import { logout } from "../../auth/authSlice";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { hideLoading, showLoading } from "@/lib/store/loadingSlice";
+import { Reservation } from "@/types/reservation";
+import { Review } from "@/types/reivew";
 
 export interface User {
   id: number;
@@ -96,6 +98,68 @@ export const updateUserRole = createAsyncThunk<
         dispatch(logout());
       }
       return rejectWithValue("Failed to update user role");
+    }
+  }
+);
+
+export const fetchUserReservations = createAsyncThunk<
+  Reservation[],
+  number,
+  { rejectValue: string; state: RootState }
+>(
+  "/admin/fetchUserReservations",
+  async (userId, { dispatch, rejectWithValue, getState }) => {
+    try {
+      dispatch(showLoading());
+      const token = getState().auth.accessToken;
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user/${userId}/reservations`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data;
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to fetch user reservations");
+    } finally {
+      dispatch(hideLoading());
+    }
+  }
+);
+
+export const fetchUserReviews = createAsyncThunk<
+  Review[],
+  number,
+  { rejectValue: string; state: RootState }
+>(
+  "/admin/fetchUserReviews",
+  async (userId, { dispatch, rejectWithValue, getState }) => {
+    try {
+      dispatch(showLoading());
+      const token = getState().auth.accessToken;
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user/${userId}/reviews`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data;
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to fetch user reviews");
+    } finally {
+      dispatch(hideLoading());
     }
   }
 );

--- a/src/lib/admin/user/adminUserThunk.ts
+++ b/src/lib/admin/user/adminUserThunk.ts
@@ -103,18 +103,22 @@ export const updateUserRole = createAsyncThunk<
 );
 
 export const fetchUserReservations = createAsyncThunk<
-  Reservation[],
-  number,
+  {data:Reservation[]; total:number; page:number;limit:number},
+  {userId:number;page:number;limit:number},
   { rejectValue: string; state: RootState }
 >(
   "/admin/fetchUserReservations",
-  async (userId, { dispatch, rejectWithValue, getState }) => {
+  async ({userId,page,limit}, { dispatch, rejectWithValue, getState }) => {
     try {
       dispatch(showLoading());
       const token = getState().auth.accessToken;
       const res = await axios.get(
         `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user/${userId}/reservations`,
         {
+          params: {
+            page,
+            limit,
+          },
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -134,18 +138,22 @@ export const fetchUserReservations = createAsyncThunk<
 );
 
 export const fetchUserReviews = createAsyncThunk<
-  Review[],
-  number,
+  {data:Review[]; total:number; page:number; limit:number},
+  {userId:number; page:number; limit:number},
   { rejectValue: string; state: RootState }
 >(
   "/admin/fetchUserReviews",
-  async (userId, { dispatch, rejectWithValue, getState }) => {
+  async ({userId, page, limit}, { dispatch, rejectWithValue, getState }) => {
     try {
       dispatch(showLoading());
       const token = getState().auth.accessToken;
       const res = await axios.get(
         `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user/${userId}/reviews`,
         {
+          params: {
+            page,
+            limit,
+          },
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -163,3 +171,4 @@ export const fetchUserReviews = createAsyncThunk<
     }
   }
 );
+


### PR DESCRIPTION
# Pull Request

## Description  
- Implemented `admin/users/[userId]/page.tsx` in the frontend to display detailed user management view
- Added sections to show user's basic info, reservations, and reviews
- Integrated role change and user deletion actions
- Enhanced frontend pagination for reservations and reviews with page/limit support
- Connected pagination buttons to dispatch API requests for specific pages


## Why  
- Allows admins to manage individual users more effectively
- Enables viewing a user's reservations and reviews without overwhelming UI
- Pagination improves performance and usability by loading only part of the data at once
- Supports future scalability as the number of reservations and reviews grows


## Testing  
- Ran the Next.js app locally
- Navigated to `/admin/users` and clicked on a user to visit their detail page
- Verified user info displays correctly
- Used pagination controls to navigate through reservations and reviews
- Checked that changing role and deleting users worked as expected
- Tested with different page sizes to confirm API integration

## Linked Issues  
Fixes #51 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [x] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
