### PR TITLE
Feat/admin

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -8,11 +8,12 @@ import {
   updateUserRole,
 } from "@/lib/admin/user/adminUserThunk";
 import { AppDispatch, RootState } from "@/lib/store/store";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 export default function AdminUsersPage() {
   const dispatch: AppDispatch = useAppDispatch();
   const router = useRouter();
+  const pathname = usePathname();
 
   const { list, state, error, total, page, limit } = useAppSelector(
     (state: RootState) => state["admin/user"]
@@ -24,7 +25,9 @@ export default function AdminUsersPage() {
 
 
   useEffect(() => {
+    if(pathname === "/admin/users") {
     dispatch(fetchAllUsers({ page, limit }));
+    }
   }, [dispatch]);
 
   const handleDelete = (userId: number) => {

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -64,7 +64,7 @@ export default function AdminUsersPage() {
             ))}
           </tbody>
         </table>
-        <div className="flex justify-between items-center mt-4">
+        <div className="flex justify-center items-center mt-4 gap-5">
             <button
               onClick={() => handlePageChange(page - 1)}
               disabled={page <= 1}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -18,10 +18,10 @@ export default function AdminUsersPage() {
     dispatch(fetchAllUsers({ page, limit }));
   }, [dispatch]);
 
-  const handleDelete = (userId: number) => {
-    if (window.confirm("정말 이 사용자를 삭제하시겠습니까?")) {
-      dispatch(deleteUser(userId));
-    }
+  const handlePageChange = (newPage: number) => {
+    if (newPage < 1) return;
+    if (newPage > Math.ceil(total / limit)) return;
+    dispatch(fetchAllUsers({ page: newPage, limit }));
   };
 
   return (
@@ -35,6 +35,7 @@ export default function AdminUsersPage() {
       )}
 
       {state === "succeeded" && Array.isArray(list) && list.length > 0 && (
+        <>
         <table className="min-w-full border border-gray-300">
           <thead>
             <tr className="bg-gray-100">
@@ -63,6 +64,34 @@ export default function AdminUsersPage() {
             ))}
           </tbody>
         </table>
+        <div className="flex justify-between items-center mt-4">
+            <button
+              onClick={() => handlePageChange(page - 1)}
+              disabled={page <= 1}
+              className={`px-4 py-2 rounded ${
+                page <= 1
+                  ? "bg-gray-300 cursor-not-allowed"
+                  : "bg-blue-500 text-white hover:bg-blue-600"
+              }`}
+            >
+              이전
+            </button>
+            <span className="text-gray-700">
+              Page {page} of {Math.ceil(total / limit)}
+            </span>
+            <button
+              onClick={() => handlePageChange(page + 1)}
+              disabled={page * limit >= total}
+              className={`px-4 py-2 rounded ${
+                page * limit >= total
+                  ? "bg-gray-300 cursor-not-allowed"
+                  : "bg-blue-500 text-white hover:bg-blue-600"
+              }`}
+            >
+              다음
+            </button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -19,6 +19,11 @@ export default function AdminUsersPage() {
   );
 
   useEffect(() => {
+  console.log("list in page:", list);
+}, [list]);
+
+
+  useEffect(() => {
     dispatch(fetchAllUsers({ page, limit }));
   }, [dispatch]);
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -2,32 +2,20 @@
 
 import React, { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
-import {
-  fetchAllUsers,
-  deleteUser,
-  updateUserRole,
-} from "@/lib/admin/user/adminUserThunk";
+import { fetchAllUsers, deleteUser } from "@/lib/admin/user/adminUserThunk";
 import { AppDispatch, RootState } from "@/lib/store/store";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 export default function AdminUsersPage() {
   const dispatch: AppDispatch = useAppDispatch();
   const router = useRouter();
-  const pathname = usePathname();
 
   const { list, state, error, total, page, limit } = useAppSelector(
     (state: RootState) => state["admin/user"]
   );
 
   useEffect(() => {
-  console.log("list in page:", list);
-}, [list]);
-
-
-  useEffect(() => {
-    if(pathname === "/admin/users") {
     dispatch(fetchAllUsers({ page, limit }));
-    }
   }, [dispatch]);
 
   const handleDelete = (userId: number) => {
@@ -55,7 +43,6 @@ export default function AdminUsersPage() {
               <th className="p-2 border">닉네임</th>
               <th className="p-2 border">권한</th>
               <th className="p-2 border">가입일</th>
-              <th className="p-2 border">관리</th>
             </tr>
           </thead>
           <tbody>
@@ -71,14 +58,6 @@ export default function AdminUsersPage() {
                 <td className="p-2 border text-center">{user.role}</td>
                 <td className="p-2 border text-center">
                   {new Date(user.createdAt).toLocaleDateString()}
-                </td>
-                <td className="p-2 border text-center">
-                  <button
-                    onClick={() => handleDelete(user.id)}
-                    className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
-                  >
-                    삭제
-                  </button>
                 </td>
               </tr>
             ))}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -14,12 +14,12 @@ export default function AdminUsersPage() {
   const dispatch: AppDispatch = useAppDispatch();
   const router = useRouter();
 
-  const { list, state, error } = useAppSelector(
+  const { list, state, error, total, page, limit } = useAppSelector(
     (state: RootState) => state["admin/user"]
   );
 
   useEffect(() => {
-    dispatch(fetchAllUsers());
+    dispatch(fetchAllUsers({ page, limit }));
   }, [dispatch]);
 
   const handleDelete = (userId: number) => {
@@ -34,11 +34,11 @@ export default function AdminUsersPage() {
 
       {state === "failed" && <div className="text-red-500">Error: {error}</div>}
 
-      {state === "succeeded" && list.length === 0 && (
+      {state === "succeeded" && Array.isArray(list) && list.length === 0 && (
         <div className="text-gray-500">No users found.</div>
       )}
 
-      {state === "succeeded" && list.length > 0 && (
+      {state === "succeeded" && Array.isArray(list) && list.length > 0 && (
         <table className="min-w-full border border-gray-300">
           <thead>
             <tr className="bg-gray-100">

--- a/src/lib/admin/user/adminUserSlice.ts
+++ b/src/lib/admin/user/adminUserSlice.ts
@@ -67,7 +67,7 @@ const adminUserSlice = createSlice({
       })
       .addCase(fetchAllUsers.fulfilled, (state, action) => {
         state.state = "succeeded";
-        state.list = action.payload.data;
+        state.list = action.payload.list;
         state.total = action.payload.total;
         state.page = action.payload.page;
         state.limit = action.payload.limit;

--- a/src/lib/admin/user/adminUserSlice.ts
+++ b/src/lib/admin/user/adminUserSlice.ts
@@ -22,6 +22,9 @@ interface UserState {
   reviewLimit: number;
   state: "idle" | "loading" | "succeeded" | "failed";
   error: string | null;
+  total: number;
+  page: number;
+  limit: number;
 }
 
 const initialState: UserState = {
@@ -36,6 +39,9 @@ const initialState: UserState = {
   reviewLimit: 10,
   state: "idle",
   error: null,
+  total: 0,
+  page: 1,
+  limit: 10,
 };
 
 const adminUserSlice = createSlice({
@@ -61,7 +67,10 @@ const adminUserSlice = createSlice({
       })
       .addCase(fetchAllUsers.fulfilled, (state, action) => {
         state.state = "succeeded";
-        state.list = action.payload;
+        state.list = action.payload.data;
+        state.total = action.payload.total;
+        state.page = action.payload.page;
+        state.limit = action.payload.limit;
       })
       .addCase(fetchAllUsers.rejected, (state, action) => {
         state.state = "failed";

--- a/src/lib/admin/user/adminUserThunk.ts
+++ b/src/lib/admin/user/adminUserThunk.ts
@@ -15,12 +15,12 @@ export interface User {
 }
 
 export const fetchAllUsers = createAsyncThunk<
-  { data: User[]; total: number; page: number; limit: number },
+  { list: User[]; total: number; page: number; limit: number },
   { page?: number; limit?: number },
   { rejectValue: string; state: RootState }
 >(
   "/admin/fetchAllUsers",
-  async ({ page, limit }, { dispatch, rejectWithValue, getState }) => {
+  async ({ page = 1, limit = 10 }, { dispatch, rejectWithValue, getState }) => {
     try {
       dispatch(showLoading());
       const token = getState().auth.accessToken;
@@ -38,11 +38,18 @@ export const fetchAllUsers = createAsyncThunk<
         }
       );
 
+      console.log("Server raw res.data:", res.data);
+
       if (!res.data || !Array.isArray(res.data.data)) {
         return rejectWithValue("Invalid server response");
       }
 
-      return res.data;
+      return {
+        list: res.data.data,
+        total: res.data.total,
+        page: res.data.page,
+        limit: res.data.limit,
+      };
     } catch (err: any) {
       if (err.response?.status === 401 || err.response?.status === 403) {
         dispatch(logout());

--- a/src/lib/admin/user/adminUserThunk.ts
+++ b/src/lib/admin/user/adminUserThunk.ts
@@ -15,23 +15,27 @@ export interface User {
 }
 
 export const fetchAllUsers = createAsyncThunk<
-  User[],
-  void,
+  {data:User[]; total:number; page:number; limit:number},
+  {page?: number; limit?: number},
   { rejectValue: string; state: RootState }
->("/admin/fetchAllUsers", async (_, { dispatch, rejectWithValue, getState }) => {
+>("/admin/fetchAllUsers", async ({page, limit}, { dispatch, rejectWithValue, getState }) => {
   try {
     dispatch(showLoading())
     const token = getState().auth.accessToken;
     const res = await axios.get(
       `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user`,
       {
+        params: {
+          page,
+          limit,
+        },
         headers: {
           Authorization: `Bearer ${token}`,
         },
         withCredentials: true,
       }
     );
-    return res.data;
+    return res.data.data;
   } catch (err: any) {
     if (err.response?.status === 401 || err.response?.status === 403) {
       dispatch(logout());

--- a/src/lib/admin/user/adminUserThunk.ts
+++ b/src/lib/admin/user/adminUserThunk.ts
@@ -38,12 +38,6 @@ export const fetchAllUsers = createAsyncThunk<
         }
       );
 
-      console.log("Server raw res.data:", res.data);
-
-      if (!res.data || !Array.isArray(res.data.data)) {
-        return rejectWithValue("Invalid server response");
-      }
-
       return {
         list: res.data.data,
         total: res.data.total,

--- a/src/lib/admin/user/adminUserThunk.ts
+++ b/src/lib/admin/user/adminUserThunk.ts
@@ -15,36 +15,44 @@ export interface User {
 }
 
 export const fetchAllUsers = createAsyncThunk<
-  {data:User[]; total:number; page:number; limit:number},
-  {page?: number; limit?: number},
+  { data: User[]; total: number; page: number; limit: number },
+  { page?: number; limit?: number },
   { rejectValue: string; state: RootState }
->("/admin/fetchAllUsers", async ({page, limit}, { dispatch, rejectWithValue, getState }) => {
-  try {
-    dispatch(showLoading())
-    const token = getState().auth.accessToken;
-    const res = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user`,
-      {
-        params: {
-          page,
-          limit,
-        },
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        withCredentials: true,
+>(
+  "/admin/fetchAllUsers",
+  async ({ page, limit }, { dispatch, rejectWithValue, getState }) => {
+    try {
+      dispatch(showLoading());
+      const token = getState().auth.accessToken;
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/user`,
+        {
+          params: {
+            page,
+            limit,
+          },
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+
+      if (!res.data || !Array.isArray(res.data.data)) {
+        return rejectWithValue("Invalid server response");
       }
-    );
-    return res.data.data;
-  } catch (err: any) {
-    if (err.response?.status === 401 || err.response?.status === 403) {
-      dispatch(logout());
+
+      return res.data;
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to fetch users");
+    } finally {
+      dispatch(hideLoading());
     }
-    return rejectWithValue("Failed to fetch users");
-  } finally {
-    dispatch(hideLoading());
   }
-});
+);
 
 export const deleteUser = createAsyncThunk<
   { message: string; user: User },
@@ -107,12 +115,12 @@ export const updateUserRole = createAsyncThunk<
 );
 
 export const fetchUserReservations = createAsyncThunk<
-  {data:Reservation[]; total:number; page:number;limit:number},
-  {userId:number;page:number;limit:number},
+  { data: Reservation[]; total: number; page: number; limit: number },
+  { userId: number; page: number; limit: number },
   { rejectValue: string; state: RootState }
 >(
   "/admin/fetchUserReservations",
-  async ({userId,page,limit}, { dispatch, rejectWithValue, getState }) => {
+  async ({ userId, page, limit }, { dispatch, rejectWithValue, getState }) => {
     try {
       dispatch(showLoading());
       const token = getState().auth.accessToken;
@@ -142,12 +150,12 @@ export const fetchUserReservations = createAsyncThunk<
 );
 
 export const fetchUserReviews = createAsyncThunk<
-  {data:Review[]; total:number; page:number; limit:number},
-  {userId:number; page:number; limit:number},
+  { data: Review[]; total: number; page: number; limit: number },
+  { userId: number; page: number; limit: number },
   { rejectValue: string; state: RootState }
 >(
   "/admin/fetchUserReviews",
-  async ({userId, page, limit}, { dispatch, rejectWithValue, getState }) => {
+  async ({ userId, page, limit }, { dispatch, rejectWithValue, getState }) => {
     try {
       dispatch(showLoading());
       const token = getState().auth.accessToken;
@@ -175,4 +183,3 @@ export const fetchUserReviews = createAsyncThunk<
     }
   }
 );
-


### PR DESCRIPTION
# Pull Request

## Description  
- Implemented pagination controls (Previous/Next) in `admin/users/page.tsx`
- Refactored `fetchAllUsers` thunk to accept `page` and `limit` parameters
- Updated `adminUserSlice` to store and manage pagination state (page, limit, total)
- Improved UI with pagination buttons and current page indicator

## Why  
- Enables admin users to navigate through the entire user list without loading all users at once
- Reduces server load and improves frontend performance
- Makes user management scalable and easier to use for large datasets

## Testing  
- Ran the app locally
- Verified that user list fetches page 1 on initial load
- Tested Previous/Next buttons to confirm correct data loads for each page
- Checked that buttons disable correctly on first/last pages
- Inspected Redux state to ensure `page`, `limit`, and `total` update correctly


## Linked Issues  
Fixes #54 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
