### PR TITLE
Feat/ticket

### DIFF
--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import {
   deleteReportedReview,
@@ -8,111 +8,204 @@ import {
   fetchReports,
   hideReportReview,
 } from "@/lib/admin/reports/reportsThunk";
-// import { useDeleteReviewMutation } from "@/lib/review/reviewApi";
+import {
+  fetchTicketReports,
+  deleteTicketReportedReview,
+  deleteTicketReviewOnly,
+  hideTicketReportReview,
+} from "@/lib/admin/reports/ticketReportsThunk";
 
 export default function ReportReviewsPage() {
-  const dispatch = useAppDispatch();
-  const { list, state, error, total, page, limit } = useAppSelector(
-    (state) => state["admin/reports"]
-  );
+  const [filter, setFilter] = useState<"all" | "lodges" | "tickets">("all");
 
-  // const [deleteReview] = useDeleteReviewMutation()
+  const dispatch = useAppDispatch();
+
+  const lodgeReports = useAppSelector((state) => state["admin/reports"]);
+  const ticketReports = useAppSelector((state) => state["admin/ticketReports"]);
+
+  const lodgePage = lodgeReports?.page ?? 1;
+  const ticketPage = ticketReports?.page ?? 1;
+  const limit = lodgeReports?.limit ?? 10;
 
   useEffect(() => {
-    dispatch(fetchReports({ page, limit }));
-  }, [dispatch, page, limit]);
+    if (filter === "lodges" || filter === "all") {
+      dispatch(fetchReports({ page: lodgePage, limit }));
+    }
+    if (filter === "tickets" || filter === "all") {
+      dispatch(fetchTicketReports({ page: ticketPage, limit }));
+    }
+  }, [dispatch, filter, lodgePage, ticketPage, limit]);
 
-  const handleDeleteFromReports = (reviewId: number) => {
-    dispatch(deleteReportedReview(reviewId));
+  const handleDeleteFromReports = (reviewId: number, isTicket: boolean) => {
+    if (isTicket) {
+      dispatch(deleteTicketReportedReview(reviewId));
+    } else {
+      dispatch(deleteReportedReview(reviewId));
+    }
   };
 
-  const handleHide = (reviewId: number, isHidden: boolean) => {
+  const handleHide = (
+    reviewId: number,
+    isHidden: boolean,
+    isTicket: boolean
+  ) => {
     if (confirm("리뷰를 숨기거나 표시하시겠습니까?")) {
-      dispatch(hideReportReview({ reviewId, isHidden }));
+      if (isTicket) {
+        dispatch(hideTicketReportReview({ reviewId, isHidden }));
+      } else {
+        dispatch(hideReportReview({ reviewId, isHidden }));
+      }
     }
   };
 
-  const handleDeleteReview = async (reviewId: number) => {
-    try {
-      dispatch(deleteReviewOnly(reviewId));
-      alert("리뷰가 성공적으로 삭제되었습니다.");
-      dispatch(fetchReports({ page, limit }));
-    } catch (error) {
-      alert("리뷰 삭제에 실패했습니다.");
+  const handleDeleteReview = (reviewId: number, isTicket: boolean) => {
+    if (confirm("리뷰를 정말 삭제하시겠습니까?")) {
+      if (isTicket) {
+        dispatch(deleteTicketReviewOnly(reviewId));
+      } else {
+        dispatch(deleteReviewOnly(reviewId));
+      }
     }
   };
+
+  const combinedList =
+    filter === "all"
+      ? [
+          ...lodgeReports.list.map((r) => ({ ...r, isTicket: false })),
+          ...ticketReports.list.map((r) => ({ ...r, isTicket: true })),
+        ]
+      : filter === "lodges"
+      ? lodgeReports.list.map((r) => ({ ...r, isTicket: false }))
+      : ticketReports.list.map((r) => ({ ...r, isTicket: true }));
+
+  const loading =
+    lodgeReports.state === "loading" || ticketReports.state === "loading";
+  const error = lodgeReports.error || ticketReports.error;
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">신고된 댓글</h1>
+      <h1 className="text-2xl font-bold mb-4">신고된 댓글 관리</h1>
 
-      {state === "loading" && <p>Loading...</p>}
-      {state === "failed" && <p className="text-red-500">{error}</p>}
-      {state === "succeeded" && list.length === 0 && <p>No reports found.</p>}
+      <div className="flex space-x-4 mb-6">
+        <button
+          onClick={() => setFilter("all")}
+          className={`px-4 py-2 rounded ${
+            filter === "all" ? "bg-blue-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          전체 보기
+        </button>
+        <button
+          onClick={() => setFilter("lodges")}
+          className={`px-4 py-2 rounded ${
+            filter === "lodges" ? "bg-blue-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          숙소 리뷰
+        </button>
+        <button
+          onClick={() => setFilter("tickets")}
+          className={`px-4 py-2 rounded ${
+            filter === "tickets" ? "bg-blue-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          티켓 리뷰
+        </button>
+      </div>
+
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      {!loading && combinedList.length === 0 && <p>No reports found.</p>}
 
       <div className="space-y-4">
-        {list.map((report) => (
-          <div
-            key={report.id}
-            className="border rounded-lg p-4 shadow-sm bg-white"
-          >
-            <div className="mb-2">
-              <strong>신고 사유:</strong> {report.reason}
-            </div>
-            <div className="mb-2">
-              <strong>신고자:</strong> {report.user.nickname}
-            </div>
-            <div className="mb-2">
-              <strong>신고된 댓글:</strong> {report.review.comment}
-            </div>
-            <div className="mb-2">
-              <strong>댓글 작성자:</strong> {report.review.user.nickname}
-            </div>
-            <div className="mb-2">
-              <strong>숙소명:</strong> {report.review.lodge.name}
-            </div>
-            <div className="mb-2">
-              <strong>숨김처리:</strong> {report.review.isHidden ? "Yes" : "No"}
-            </div>
+        {combinedList
+          .sort(
+            (a, b) =>
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          )
+          .map((report) => (
+            <div
+              key={`${report.isTicket ? "ticket" : "lodge"}-${report.id}`}
+              className="border rounded-lg p-4 shadow-sm bg-white"
+            >
+              <div className="mb-2">
+                <strong>신고 사유:</strong> {report.reason}
+              </div>
+              <div className="mb-2">
+                <strong>신고자:</strong> {report.user.nickname}
+              </div>
+              <div className="mb-2">
+                <strong>신고된 댓글:</strong> {report.review.comment}
+              </div>
+              <div className="mb-2">
+                <strong>댓글 작성자:</strong> {report.review.user.nickname}
+              </div>
+              {report.isTicket ? (
+                <div className="mb-2">
+                  <strong>티켓 타입:</strong>{" "}
+                  {(report.review as any).ticketType?.name}
+                </div>
+              ) : (
+                <div className="mb-2">
+                  <strong>숙소명:</strong> {(report.review as any).lodge?.name}
+                </div>
+              )}
+              <div className="mb-2">
+                <strong>숨김처리:</strong>{" "}
+                {report.review.isHidden ? "Yes" : "No"}
+              </div>
 
-            <div className="flex space-x-2 mt-4">
-              <button
-                className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
-                onClick={() => handleDeleteFromReports(report.review.id)}
-              >
-                신고 해결
-              </button>
-              <button
-                className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
-                onClick={() => {
-                  if (report?.review?.id !== null) {
-                    handleDeleteReview(report.review.id);
-                  } else {
-                    alert("리뷰 ID가 없습니다.");
+              <div className="flex space-x-2 mt-4">
+                <button
+                  className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+                  onClick={() =>
+                    handleDeleteFromReports(report.review.id, report.isTicket)
                   }
-                }}
-              >
-                리뷰 삭제
-              </button>
-              <button
-                className="bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600"
-                onClick={() =>
-                  handleHide(report.review.id, !report.review.isHidden)
-                }
-              >
-                {report.review.isHidden ? "표시하기" : "숨기기"}
-              </button>
+                >
+                  신고 해결
+                </button>
+                <button
+                  className="bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600"
+                  onClick={() =>
+                    handleDeleteReview(report.review.id, report.isTicket)
+                  }
+                >
+                  리뷰 삭제
+                </button>
+                <button
+                  className="bg-yellow-500 text-white px-3 py-1 rounded hover:bg-yellow-600"
+                  onClick={() =>
+                    handleHide(
+                      report.review.id,
+                      !report.review.isHidden,
+                      report.isTicket
+                    )
+                  }
+                >
+                  {report.review.isHidden ? "표시하기" : "숨기기"}
+                </button>
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
 
-        {state === "succeeded" && total > 0 && (
+        {/* 페이지네이션 */}
+        {filter !== "all" && (
           <div className="flex justify-center items-center space-x-4 mt-8">
             <button
-              disabled={page <= 1}
-              onClick={() => dispatch(fetchReports({ page: page - 1, limit }))}
+              disabled={
+                (filter === "lodges" && lodgePage <= 1) ||
+                (filter === "tickets" && ticketPage <= 1)
+              }
+              onClick={() =>
+                filter === "lodges"
+                  ? dispatch(fetchReports({ page: lodgePage - 1, limit }))
+                  : dispatch(
+                      fetchTicketReports({ page: ticketPage - 1, limit })
+                    )
+              }
               className={`px-4 py-2 rounded ${
-                page <= 1
+                (filter === "lodges" && lodgePage <= 1) ||
+                (filter === "tickets" && ticketPage <= 1)
                   ? "bg-gray-300 text-gray-500 cursor-not-allowed"
                   : "bg-blue-500 text-white hover:bg-blue-600"
               } transition`}
@@ -121,14 +214,33 @@ export default function ReportReviewsPage() {
             </button>
 
             <span className="text-gray-700 font-medium">
-              Page {page} / {Math.max(1, Math.ceil(total / limit))} ({total} 건)
+              Page {filter === "lodges" ? lodgePage : ticketPage} /{" "}
+              {filter === "lodges"
+                ? Math.max(1, Math.ceil(lodgeReports.total / limit))
+                : Math.max(1, Math.ceil(ticketReports.total / limit))}{" "}
+              ({filter === "lodges" ? lodgeReports.total : ticketReports.total}{" "}
+              건)
             </span>
 
             <button
-              disabled={page >= Math.ceil(total / limit)}
-              onClick={() => dispatch(fetchReports({ page: page + 1, limit }))}
+              disabled={
+                (filter === "lodges" &&
+                  lodgePage >= Math.ceil(lodgeReports.total / limit)) ||
+                (filter === "tickets" &&
+                  ticketPage >= Math.ceil(ticketReports.total / limit))
+              }
+              onClick={() =>
+                filter === "lodges"
+                  ? dispatch(fetchReports({ page: lodgePage + 1, limit }))
+                  : dispatch(
+                      fetchTicketReports({ page: ticketPage + 1, limit })
+                    )
+              }
               className={`px-4 py-2 rounded ${
-                page >= Math.ceil(total / limit)
+                (filter === "lodges" &&
+                  lodgePage >= Math.ceil(lodgeReports.total / limit)) ||
+                (filter === "tickets" &&
+                  ticketPage >= Math.ceil(ticketReports.total / limit))
                   ? "bg-gray-300 text-gray-500 cursor-not-allowed"
                   : "bg-blue-500 text-white hover:bg-blue-600"
               } transition`}

--- a/src/lib/admin/reports/ticketReportsSlice.ts
+++ b/src/lib/admin/reports/ticketReportsSlice.ts
@@ -1,0 +1,125 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {
+  fetchTicketReports,
+  deleteTicketReportedReview,
+  hideTicketReportReview,
+  deleteTicketReviewOnly,
+  TicketReportReviews,
+  TicketReportReviewsPagination,
+} from "./ticketReportsThunk";
+
+interface TicketReportsState {
+  list: TicketReportReviews[];
+  total: number;
+  page: number;
+  limit: number;
+  state: "idle" | "loading" | "succeeded" | "failed";
+  error: string | null;
+}
+
+const initialState: TicketReportsState = {
+  list: [],
+  total: 0,
+  page: 1,
+  limit: 10,
+  state: "idle",
+  error: null,
+};
+
+const ticketReportsSlice = createSlice({
+  name: "admin/ticketReports",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchTicketReports.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        fetchTicketReports.fulfilled,
+        (state, action: PayloadAction<TicketReportReviewsPagination>) => {
+          state.state = "succeeded";
+          state.list = action.payload.data;
+          state.total = action.payload.total;
+          state.page = action.payload.page;
+          state.limit = action.payload.limit;
+        }
+      )
+      .addCase(fetchTicketReports.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      });
+
+    builder
+      .addCase(deleteTicketReportedReview.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        deleteTicketReportedReview.fulfilled,
+        (
+          state,
+          action: PayloadAction<{ message: string; reviewId: number }>
+        ) => {
+          state.state = "succeeded";
+          const deletedId = action.payload.reviewId;
+          state.list = state.list.filter(
+            (report) => report.review.id !== deletedId
+          );
+        }
+      )
+      .addCase(deleteTicketReportedReview.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      });
+
+    builder
+      .addCase(hideTicketReportReview.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        hideTicketReportReview.fulfilled,
+        (
+          state,
+          action: PayloadAction<{
+            message: string;
+            updated: { id: number; isHidden: boolean };
+          }>
+        ) => {
+          state.state = "succeeded";
+          const { id: hiddenReviewId, isHidden } = action.payload.updated;
+          const index = state.list.findIndex(
+            (item) => item.review.id === hiddenReviewId
+          );
+          if (index !== -1) {
+            state.list[index].review.isHidden = isHidden;
+          }
+        }
+      )
+      .addCase(hideTicketReportReview.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      });
+
+    builder
+      .addCase(deleteTicketReviewOnly.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(deleteTicketReviewOnly.fulfilled, (state, action) => {
+        state.state = "succeeded";
+        const deletedId = action.payload.reviewId;
+        state.list = state.list.filter(
+          (report) => report.review.id !== deletedId
+        );
+      })
+      .addCase(deleteTicketReviewOnly.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export default ticketReportsSlice.reducer;

--- a/src/lib/admin/reports/ticketReportsThunk.ts
+++ b/src/lib/admin/reports/ticketReportsThunk.ts
@@ -1,0 +1,172 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { logout } from "../../auth/authSlice";
+import { RootState } from "@/lib/store/store";
+import { hideLoading, showLoading } from "@/lib/store/loadingSlice";
+
+export interface TicketReportReviews {
+  id: number;
+  reviewId: number;
+  userId: number;
+  reason: string;
+  createdAt: string;
+
+  review: {
+    id: number;
+    ticketTypeId: number;
+    userId: number;
+    rating: number;
+    comment: string;
+    isHidden: boolean;
+    createdAt: string;
+    ticketType: {
+      id: number;
+      name: string;
+    };
+    user: {
+      id: number;
+      nickname: string;
+    };
+  };
+
+  user: {
+    id: number;
+    nickname: string;
+  };
+}
+
+export interface TicketReportReviewsPagination {
+  data: TicketReportReviews[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export const fetchTicketReports = createAsyncThunk<
+  TicketReportReviewsPagination,
+  { page?: number; limit?: number },
+  { rejectValue: string; state: RootState }
+>(
+  "admin/fetchTicketReports",
+  async ({ page = 1, limit = 10 }, { dispatch, rejectWithValue, getState }) => {
+    try {
+      dispatch(showLoading());
+      const token = getState().auth.accessToken;
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reports`,
+        {
+          params: { page, limit },
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data as TicketReportReviewsPagination;
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to fetch ticket reports");
+    } finally {
+      dispatch(hideLoading());
+    }
+  }
+);
+
+export const deleteTicketReportedReview = createAsyncThunk<
+  { message: string; reviewId: number },
+  number,
+  { rejectValue: string; state: RootState }
+>(
+  "admin/deleteTicketReportedReview",
+  async (reviewId, { dispatch, rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const res = await axios.delete(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reports/report-only/${reviewId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data as { message: string; reviewId: number };
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to delete ticket reported review");
+    }
+  }
+);
+
+export const hideTicketReportReview = createAsyncThunk<
+  { message: string; updated: { id: number; isHidden: boolean } },
+  { reviewId: number; isHidden: boolean },
+  { rejectValue: string; state: RootState }
+>(
+  "admin/hideTicketReportReview",
+  async ({ reviewId, isHidden }, { dispatch, rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const res = await axios.patch(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reports/review/${reviewId}/hide`,
+        { isHidden },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+
+      const data = res.data as {
+        message: string;
+        updated: { id: number; isHidden: boolean };
+      };
+
+      return {
+        message: data.message,
+        updated: {
+          id: data.updated.id,
+          isHidden: data.updated.isHidden,
+        },
+      };
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to hide ticket review");
+    }
+  }
+);
+
+export const deleteTicketReviewOnly = createAsyncThunk<
+  { message: string; reviewId: number },
+  number,
+  { rejectValue: string; state: RootState }
+>(
+  "admin/deleteTicketReviewOnly",
+  async (reviewId, { dispatch, rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const res = await axios.delete(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reports/review-only/${reviewId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return res.data as { message: string; reviewId: number };
+    } catch (err: any) {
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        dispatch(logout());
+      }
+      return rejectWithValue("Failed to delete ticket review");
+    }
+  }
+);

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -18,6 +18,7 @@ import { reportReviewApi } from "../report-review/reportReviewApi";
 import loadingReducer from "./loadingSlice";
 import adminReservationReducer from "../admin/reservation/reservationSlice";
 import { userServiceApi } from "../user/userApi";
+import reportsTicketReducer from "../admin/reports/ticketReportsSlice";
 
 export const store = configureStore({
   reducer: {
@@ -31,6 +32,7 @@ export const store = configureStore({
     "admin/reports": reportsReducer,
     "admin/roomInventory": roomInventoryReducer,
     "admin/roomPricing": roomPricingReducer,
+    "admin/ticketReports": reportsTicketReducer,
     adminReservation : adminReservationReducer,
     [lodgeApi.reducerPath]: lodgeApi.reducer,
     [priceApi.reducerPath]: priceApi.reducer,


### PR DESCRIPTION
# Pull Request

## Description  
- Integrated calling of new TicketReportReview API from the backend in the frontend admin dashboard
- Added Redux thunk and slice logic for fetching, hiding, deleting ticket review reports
- Refactored `admin/reports/page.tsx` to support three views via tabbed filter:
  - All (lodges + tickets)
  - Lodges only
  - Tickets only
- Combined and sorted lodge and ticket reports for "All" view
- Updated pagination logic to support separate page state for lodges and tickets
- Improved type safety and conditional rendering based on report type


## Why  
- To enable administrators to moderate not only lodge reviews but also ticket reviews
- To support viewing, hiding, resolving, and deleting reported ticket reviews alongside existing lodge reviews
- To offer a clear UI for switching between report types in the admin dashboard
- To improve maintainability and clarity of the report management page by refactoring and consolidating logic


## Testing  
- Ran the development server locally
- Verified fetching and rendering of:
  - Lodges-only reports
  - Tickets-only reports
  - Combined “All” reports view
- Confirmed ability to:
  - Hide/unhide individual reviews
  - Delete only reports (resolve reports)
  - Delete entire reviews (including cascade-deleting reports)
- Checked pagination for both lodge and ticket reports independently
- Verified correct API calls to:
  - `/v1/admin/reports` (lodges)
  - `/v1/admin/ticket-reports` (tickets)

## Linked Issues  
Fixes #64 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [x] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
