### PR TITLE
Feat/ticket

### DIFF
--- a/src/app/admin/reservations/page.tsx
+++ b/src/app/admin/reservations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import {
   getAllReservations,
@@ -8,47 +8,107 @@ import {
 } from "@/lib/admin/reservation/reservationThunk";
 import { Reservation } from "@/types/reservation";
 import { useRouter } from "next/navigation";
+import {
+  getAllTicketReservations,
+  updateTicketReservationStatus,
+} from "@/lib/admin/reservation/ticketReservationThunk";
 
 const AdminReservationsPage = () => {
+  const [filter, setFilter] = useState<"all" | "lodges" | "tickets">("all");
+
   const dispatch = useAppDispatch();
   const router = useRouter();
 
-  const { list, state, error, page, total, limit } = useAppSelector(
-    (state) => state.adminReservation
-  );
+  const lodge = useAppSelector((state) => state.adminReservation);
+  const ticket = useAppSelector((state) => state.adminTicketReservation);
+
+  const limit = 10;
 
   useEffect(() => {
-    dispatch(getAllReservations({ page: 1, limit }));
-  }, [dispatch, limit]);
+    if (filter === "lodges" || filter === "all") {
+      dispatch(getAllReservations({ page: lodge.page, limit }));
+    }
+    if (filter === "tickets" || filter === "all") {
+      dispatch(getAllTicketReservations({ page: ticket.page, limit }));
+    }
+  }, [dispatch, filter, lodge.page, ticket.page]);
+
+  const combinedList =
+    filter === "all"
+      ? [
+          ...lodge.list.map((item) => ({ ...item, type: "lodges" as const })),
+          ...ticket.list.map((item) => ({ ...item, type: "tickets" as const })),
+        ]
+      : filter === "lodges"
+      ? lodge.list.map((item) => ({ ...item, type: "lodges" as const }))
+      : ticket.list.map((item) => ({ ...item, type: "tickets" as const }));
 
   const handleUpdateStatus = (
     id: number,
+    type: "lodges" | "tickets",
     newStatus: string,
     cancelReason?: string
   ) => {
-    dispatch(
-      updateReservationStatus({
-        id,
-        status: newStatus === "CANCELED" ? "CANCELLED" : newStatus,
-        cancelReason,
-      })
-    )
-      .unwrap()
-      .then(() => {
-        dispatch(getAllReservations({ page, limit }));
-      })
-      .catch((err) => {
-        console.error(err);
-      });
+    if (type === "lodges") {
+      dispatch(updateReservationStatus({ id, status: newStatus, cancelReason }))
+        .unwrap()
+        .then(() => {
+          dispatch(getAllReservations({ page: lodge.page, limit }));
+        })
+        .catch(console.error);
+    } else {
+      dispatch(
+        updateTicketReservationStatus({ id, status: newStatus, cancelReason })
+      )
+        .unwrap()
+        .then(() => {
+          dispatch(getAllTicketReservations({ page: ticket.page, limit }));
+        })
+        .catch(console.error);
+    }
   };
+
+  const loading = lodge.state === "loading" || ticket.state === "loading";
+  const error = lodge.error || ticket.error;
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Admin Reservation Management</h1>
+      <h1 className="text-2xl font-bold mb-4">숙박/티켓 예약 관리</h1>
 
-      {state === "failed" && <p className="text-red-500">Error: {error}</p>}
+      <div className="flex space-x-4 mb-4">
+        <button
+          onClick={() => setFilter("all")}
+          className={`px-4 py-2 rounded ${
+            filter === "all" ? "bg-blue-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          전체
+        </button>
+        <button
+          onClick={() => setFilter("lodges")}
+          className={`px-4 py-2 rounded ${
+            filter === "lodges" ? "bg-blue-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          숙박
+        </button>
+        <button
+          onClick={() => setFilter("tickets")}
+          className={`px-4 py-2 rounded ${
+            filter === "tickets" ? "bg-blue-600 text-white" : "bg-gray-200"
+          }`}
+        >
+          티켓
+        </button>
+      </div>
 
-      {state === "succeeded" && (
+      {error && <p className="text-red-500">Error: {error}</p>}
+
+      {loading && <p>Loading...</p>}
+
+      {!loading && combinedList.length === 0 && <p>No reservations found.</p>}
+
+      {!loading && combinedList.length > 0 && (
         <>
           <div className="overflow-x-auto">
             <table className="min-w-full border border-gray-300">
@@ -58,63 +118,74 @@ const AdminReservationsPage = () => {
                   <th className="px-4 py-2 border">예약자명</th>
                   <th className="px-4 py-2 border">이메일</th>
                   <th className="px-4 py-2 border">전화번호</th>
-                  <th className="px-4 py-2 border">온천장</th>
-                  <th className="px-4 py-2 border">객실타입</th>
-                  <th className="px-4 py-2 border">체크인</th>
+                  <th className="px-4 py-2 border">종류</th>
+                  <th className="px-4 py-2 border">타입</th>
+                  <th className="px-4 py-2 border">체크인/사용일</th>
                   <th className="px-4 py-2 border">체크아웃</th>
                   <th className="px-4 py-2 border">상태</th>
                   <th className="px-4 py-2 border">관리</th>
                 </tr>
               </thead>
-
               <tbody>
-                {list.map((reservation: Reservation) => (
-                  <tr key={reservation.id} className="hover:bg-gray-50 cursor-pointer"
-                  onClick={() => router.push(`/admin/reservations/${reservation.id}`)}>
-                    <td className="px-4 py-2 border">{reservation.id}</td>
+                {combinedList.map((item) => (
+                  <tr
+                    key={`${item.type}-${item.id}`}
+                    className="hover:bg-gray-50 cursor-pointer"
+                    onClick={() =>
+                      router.push(
+                        `/admin/reservations/${item.id}?type=${item.type}`
+                      )
+                    }
+                  >
+                    <td className="px-4 py-2 border">{item.id}</td>
                     <td className="px-4 py-2 border">
-                      {reservation.lastName} {reservation.firstName}
+                      {item.lastName} {item.firstName}
+                    </td>
+                    <td className="px-4 py-2 border">{item.email ?? "-"}</td>
+                    <td className="px-4 py-2 border">{item.phoneNumber}</td>
+                    <td className="px-4 py-2 border">
+                      {item.type === "lodges" ? "숙박" : "티켓"}
                     </td>
                     <td className="px-4 py-2 border">
-                      {reservation.email ?? "-"}
+                      {item.type === "lodges"
+                        ? item.roomType?.name
+                        : item.ticketType?.name}
                     </td>
                     <td className="px-4 py-2 border">
-                      {reservation.phoneNumber}
+                      {item.type === "lodges"
+                        ? item.checkIn?.slice(0, 10)
+                        : item.date?.slice(0, 10)}
                     </td>
                     <td className="px-4 py-2 border">
-                      {reservation.lodge?.name}
+                      {item.type === "lodges"
+                        ? item.checkOut?.slice(0, 10)
+                        : "-"}
                     </td>
-                    <td className="px-4 py-2 border">
-                      {reservation.roomType?.name}
-                    </td>
-                    <td className="px-4 py-2 border">
-                      {reservation.checkIn.slice(0, 10)}
-                    </td>
-                    <td className="px-4 py-2 border">
-                      {reservation.checkOut.slice(0, 10)}
-                    </td>
-                    <td className="px-4 py-2 border">{reservation.status}</td>
+                    <td className="px-4 py-2 border">{item.status}</td>
                     <td className="px-4 py-2 border space-x-2">
-                      {reservation.status !== "CONFIRMED" && (
+                      {item.status !== "CONFIRMED" && (
                         <button
                           className="bg-green-500 text-white px-2 py-1 rounded hover:bg-green-600"
-                          onClick={() =>
-                            handleUpdateStatus(reservation.id, "CONFIRMED")
-                          }
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleUpdateStatus(item.id, item.type, "CONFIRMED");
+                          }}
                         >
                           승인
                         </button>
                       )}
-                      {reservation.status !== "CANCELLED" && (
+                      {item.status !== "CANCELLED" && (
                         <button
                           className="bg-red-500 text-white px-2 py-1 rounded hover:bg-red-600"
-                          onClick={() =>
+                          onClick={(e) => {
+                            e.stopPropagation();
                             handleUpdateStatus(
-                              reservation.id,
+                              item.id,
+                              item.type,
                               "CANCELLED",
                               "ADMIN_FORCED"
-                            )
-                          }
+                            );
+                          }}
                         >
                           취소
                         </button>
@@ -126,35 +197,63 @@ const AdminReservationsPage = () => {
             </table>
           </div>
 
-          <div className="flex justify-between items-center mt-4">
-            <button
-              className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
-              disabled={page <= 1}
-              onClick={() =>
-                dispatch(getAllReservations({ page: page - 1, limit }))
-              }
-            >
-              이전
-            </button>
+          {filter !== "all" && (
+            <div className="flex justify-between items-center mt-4">
+              <button
+                className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+                disabled={
+                  filter === "lodges" ? lodge.page <= 1 : ticket.page <= 1
+                }
+                onClick={() =>
+                  filter === "lodges"
+                    ? dispatch(
+                        getAllReservations({ page: lodge.page - 1, limit })
+                      )
+                    : dispatch(
+                        getAllTicketReservations({
+                          page: ticket.page - 1,
+                          limit,
+                        })
+                      )
+                }
+              >
+                이전
+              </button>
 
-            <span>
-              Page {page} / {Math.ceil(total / limit)} ({total} items)
-            </span>
+              <span>
+                Page {filter === "lodges" ? lodge.page : ticket.page} /{" "}
+                {filter === "lodges"
+                  ? Math.ceil(lodge.total / limit)
+                  : Math.ceil(ticket.total / limit)}{" "}
+                ({filter === "lodges" ? lodge.total : ticket.total} items)
+              </span>
 
-            <button
-              className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
-              disabled={page >= Math.ceil(total / limit)}
-              onClick={() =>
-                dispatch(getAllReservations({ page: page + 1, limit }))
-              }
-            >
-              다음
-            </button>
-          </div>
+              <button
+                className="px-4 py-2 bg-gray-200 rounded disabled:opacity-50"
+                disabled={
+                  filter === "lodges"
+                    ? lodge.page >= Math.ceil(lodge.total / limit)
+                    : ticket.page >= Math.ceil(ticket.total / limit)
+                }
+                onClick={() =>
+                  filter === "lodges"
+                    ? dispatch(
+                        getAllReservations({ page: lodge.page + 1, limit })
+                      )
+                    : dispatch(
+                        getAllTicketReservations({
+                          page: ticket.page + 1,
+                          limit,
+                        })
+                      )
+                }
+              >
+                다음
+              </button>
+            </div>
+          )}
         </>
       )}
-
-      {state === "idle" && <p>Loading...</p>}
     </div>
   );
 };

--- a/src/app/admin/reservations/page.tsx
+++ b/src/app/admin/reservations/page.tsx
@@ -131,11 +131,13 @@ const AdminReservationsPage = () => {
                   <tr
                     key={`${item.type}-${item.id}`}
                     className="hover:bg-gray-50 cursor-pointer"
-                    onClick={() =>
-                      router.push(
-                        `/admin/reservations/${item.id}?type=${item.type}`
-                      )
-                    }
+                    onClick={() => {
+                      if (item.type === "lodges") {
+                        router.push(`/admin/reservations/${item.id}`);
+                      } else {
+                        router.push(`/admin/reservations/ticket/${item.id}`);
+                      }
+                    }}
                   >
                     <td className="px-4 py-2 border">{item.id}</td>
                     <td className="px-4 py-2 border">

--- a/src/app/admin/reservations/ticket/[id]/page.tsx
+++ b/src/app/admin/reservations/ticket/[id]/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
+import { getTicketReservationById } from "@/lib/admin/reservation/ticketReservationThunk";
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <span className="font-medium text-gray-600">{children}</span>
+);
+
+const Field = ({ label, value }: { label: string; value: React.ReactNode }) => (
+  <div className="flex justify-between py-1 border-b border-gray-100">
+    <span className="text-gray-500">{label}</span>
+    <span className="font-semibold text-gray-800">{value}</span>
+  </div>
+);
+
+const AdminTicketReservationDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+
+  const { selected, state, error } = useAppSelector(
+    (state) => state.adminTicketReservation
+  );
+
+  useEffect(() => {
+    if (id) {
+      dispatch(getTicketReservationById(Number(id)));
+    }
+  }, [dispatch, id]);
+
+  if (state === "loading" || state === "idle") {
+    return (
+      <div className="p-10 text-center text-gray-500 text-lg">Loading...</div>
+    );
+  }
+
+  if (state === "failed") {
+    return (
+      <div className="p-10 text-center text-red-500 text-lg">
+        Error: {error ?? "Failed to load ticket reservation"}
+      </div>
+    );
+  }
+
+  if (!selected) {
+    return (
+      <div className="p-10 text-center text-gray-500">
+        <p>Reservation not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-3xl font-bold text-blue-700 mb-6">
+        🎟️ 티켓 예약 상세 (ID: {selected.id})
+      </h1>
+
+      <div className="bg-white shadow-lg rounded-xl divide-y divide-gray-200 overflow-hidden">
+        <section className="p-6">
+          <h2 className="text-xl font-semibold text-blue-600 mb-4 border-b pb-2">
+            👤 예약자 정보
+          </h2>
+          <div className="space-y-2">
+            <Field label="이름" value={`${selected.lastName} ${selected.firstName}`} />
+            <Field label="이메일" value={selected.email ?? "-"} />
+            <Field label="전화번호" value={selected.phoneNumber} />
+            {selected.user && (
+              <Field
+                label="회원 ID"
+                value={`${selected.user.id} (${selected.user.nickname})`}
+              />
+            )}
+          </div>
+        </section>
+
+        <section className="p-6 bg-gray-50">
+          <h2 className="text-xl font-semibold text-blue-600 mb-4 border-b pb-2">
+            🎫 예약 정보
+          </h2>
+          <div className="space-y-2">
+            <Field label="티켓 타입" value={selected.ticketType?.name} />
+            <Field label="사용일" value={selected.date.slice(0, 10)} />
+            <Field
+              label="인원"
+              value={`성인 ${selected.adults}명 / 어린이 ${selected.children}명`}
+            />
+            <Field
+              label="결제 금액"
+              value={`${selected.totalPrice?.toLocaleString() ?? "-"} 원`}
+            />
+            {selected.specialRequests && (
+              <Field label="특별 요청" value={selected.specialRequests} />
+            )}
+          </div>
+        </section>
+
+        <section className="p-6">
+          <h2 className="text-xl font-semibold text-blue-600 mb-4 border-b pb-2">
+            ⚙️ 상태 정보
+          </h2>
+          <div className="space-y-2">
+            <Field label="상태" value={selected.status} />
+            {selected.cancelReason && (
+              <Field label="취소 사유" value={selected.cancelReason} />
+            )}
+            <Field
+              label="생성일"
+              value={new Date(selected.createdAt).toLocaleString()}
+            />
+          </div>
+        </section>
+      </div>
+
+      <div className="mt-8 text-center">
+        <button
+          onClick={() => router.back()}
+          className="inline-flex items-center px-5 py-2 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition"
+        >
+          ← 목록으로 돌아가기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AdminTicketReservationDetailPage;

--- a/src/lib/admin/reservation/ticketReservationSlice.ts
+++ b/src/lib/admin/reservation/ticketReservationSlice.ts
@@ -1,0 +1,112 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { TicketReservation } from "@/types/ticketReservation";
+import {
+  getAllTicketReservations,
+  getTicketReservationById,
+  updateTicketReservationStatus,
+} from "./ticketReservationThunk";
+
+interface AdminTicketReservationState {
+  list: TicketReservation[];
+  total: number;
+  page: number;
+  limit: number;
+  selected: TicketReservation | null;
+  state: "idle" | "loading" | "succeeded" | "failed";
+  error: string | null;
+}
+
+const initialState: AdminTicketReservationState = {
+  list: [],
+  total: 0,
+  page: 1,
+  limit: 10,
+  selected: null,
+  state: "idle",
+  error: null,
+};
+
+const adminTicketReservationSlice = createSlice({
+  name: "admin/ticketReservation",
+  initialState,
+  reducers: {
+    clearSelectedTicketReservation(state) {
+      state.selected = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getAllTicketReservations.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        getAllTicketReservations.fulfilled,
+        (
+          state,
+          action: PayloadAction<{
+            data: TicketReservation[];
+            total: number;
+            page: number;
+            limit: number;
+          }>
+        ) => {
+          state.state = "succeeded";
+          state.list = action.payload.data;
+          state.total = action.payload.total;
+          state.page = action.payload.page;
+          state.limit = action.payload.limit;
+        }
+      )
+      .addCase(getAllTicketReservations.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload ?? "Failed to fetch ticket reservations";
+      });
+
+    builder
+      .addCase(getTicketReservationById.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+        state.selected = null;
+      })
+      .addCase(
+        getTicketReservationById.fulfilled,
+        (state, action: PayloadAction<TicketReservation>) => {
+          state.state = "succeeded";
+          state.selected = action.payload;
+        }
+      )
+      .addCase(getTicketReservationById.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload ?? "Failed to fetch ticket reservation";
+      });
+
+    builder
+      .addCase(updateTicketReservationStatus.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        updateTicketReservationStatus.fulfilled,
+        (state, action: PayloadAction<TicketReservation>) => {
+          state.state = "succeeded";
+
+          const updated = action.payload;
+          const index = state.list.findIndex((r) => r.id === updated.id);
+          if (index !== -1) {
+            state.list[index] = updated;
+          }
+          if (state.selected?.id === updated.id) {
+            state.selected = updated;
+          }
+        }
+      )
+      .addCase(updateTicketReservationStatus.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload ?? "Failed to update ticket reservation";
+      });
+  },
+});
+
+export const { clearSelectedTicketReservation } = adminTicketReservationSlice.actions;
+export default adminTicketReservationSlice.reducer;

--- a/src/lib/admin/reservation/ticketReservationThunk.ts
+++ b/src/lib/admin/reservation/ticketReservationThunk.ts
@@ -1,0 +1,94 @@
+import axios from "axios";
+import { TicketReservation } from "@/types/ticketReservation";
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { RootState } from "@/lib/store/store";
+import { hideLoading, showLoading } from "@/lib/store/loadingSlice";
+
+export const getAllTicketReservations = createAsyncThunk<
+  { data: TicketReservation[]; total: number; page: number; limit: number },
+  { page?: number; limit?: number },
+  { rejectValue: string; state: RootState }
+>(
+  `/admin/ticket-reservations`,
+  async ({ page, limit }, { rejectWithValue, getState, dispatch }) => {
+    try {
+      dispatch(showLoading());
+      const token = getState().auth.accessToken;
+      const response = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reservation`,
+        {
+          params: { page, limit },
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return response.data;
+    } catch (error) {
+      return rejectWithValue("Failed to fetch ticket reservations");
+    } finally {
+      dispatch(hideLoading());
+    }
+  }
+);
+
+export const getTicketReservationById = createAsyncThunk<
+  TicketReservation,
+  number,
+  { rejectValue: string; state: RootState }
+>(
+  `/admin/ticket-reservations/:id`,
+  async (id, { rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const response = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reservation/${id}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return response.data;
+    } catch (error) {
+      return rejectWithValue("Failed to fetch ticket reservation");
+    }
+  }
+);
+
+export const updateTicketReservationStatus = createAsyncThunk<
+  TicketReservation,
+  { id: number; status: string; cancelReason?: string },
+  { rejectValue: string; state: RootState }
+>(
+  `/admin/ticket-reservations/:id/`,
+  async (
+    { id, status, cancelReason },
+    { rejectWithValue, getState, dispatch }
+  ) => {
+    try {
+      dispatch(showLoading());
+      const token = getState().auth.accessToken;
+      const response = await axios.patch(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/ticket-reservation/${id}`,
+        {
+          status,
+          cancelReason,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          withCredentials: true,
+        }
+      );
+      return response.data;
+    } catch (error) {
+      return rejectWithValue("Failed to update ticket reservation status");
+    } finally {
+      dispatch(hideLoading());
+    }
+  }
+);

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -19,6 +19,7 @@ import loadingReducer from "./loadingSlice";
 import adminReservationReducer from "../admin/reservation/reservationSlice";
 import { userServiceApi } from "../user/userApi";
 import reportsTicketReducer from "../admin/reports/ticketReportsSlice";
+import adminTicketReservationReducer from "../admin/reservation/ticketReservationSlice";
 
 export const store = configureStore({
   reducer: {
@@ -34,6 +35,7 @@ export const store = configureStore({
     "admin/roomPricing": roomPricingReducer,
     "admin/ticketReports": reportsTicketReducer,
     adminReservation : adminReservationReducer,
+    adminTicketReservation : adminTicketReservationReducer,
     [lodgeApi.reducerPath]: lodgeApi.reducer,
     [priceApi.reducerPath]: priceApi.reducer,
     reservation: reservationReducer,

--- a/src/types/ticketReservation.ts
+++ b/src/types/ticketReservation.ts
@@ -1,0 +1,30 @@
+export interface TicketReservation {
+  id: number;
+  ticketTypeId: number;
+  userId: number;
+  date: string;
+  adults: number;
+  children: number;
+  totalPrice?: number;
+  createdAt: string;
+  status: string;
+  cancelReason?: string;
+
+  firstName: string;
+  lastName: string;
+  nationality: string;
+  phoneNumber: string;
+  email?: string;
+  specialRequests?: string;
+
+  ticketType: {
+    id: number;
+    name: string;
+  };
+
+  user: {
+    id: number;
+    nickname: string;
+    email: string;
+  };
+}


### PR DESCRIPTION
# Pull Request

## Description  
- Integrated **TicketReservation** admin API calls in the frontend
  - Added Redux Thunk and Slice for ticket reservation fetching and updating
  - Supports listing, detail fetching, and status updates for ticket reservations
- Refactored **/admin/reservations/page.tsx** to add filter buttons:
  - "전체", "숙박", "티켓" filter options
  - Combined view shows both lodge and ticket reservations in one table
  - Pagination and status update handling per filter type
- Created **/admin/reservations/ticket/[id]/page.tsx**:
  - Displays detailed info of a selected TicketReservation
  - Mirrors styling and structure of the existing lodge reservation detail page


## Why  
- Needed to support full admin management of **ticket reservations** alongside **lodge reservations**
- Enables admins to filter, view, and manage all reservations in one unified UI
- Improves usability and maintainability by standardizing reservation detail pages


## Testing  
- Ran frontend locally and confirmed:
  - Filter buttons switch between 전체/숙박/티켓 views
  - Fetches and displays correct reservation lists per type
  - Status update buttons correctly trigger PATCH APIs for lodge/ticket
  - Pagination works independently for lodge and ticket reservations
- Verified:
  - /admin/reservations/[id] shows lodge reservation detail
  - /admin/reservations/ticket/[id] shows ticket reservation detail
- Used Redux DevTools and Network panel to confirm correct API endpoints were called


## Linked Issues  
Fixes #66 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [x] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
