### PR TITLE
Feat/ticket

### DIFF
--- a/src/app/lodge/[lodgeId]/page.tsx
+++ b/src/app/lodge/[lodgeId]/page.tsx
@@ -102,7 +102,7 @@ const LodgeDetailPage = () => {
     return () => {
       document.removeEventListener("click", handleClickOutside);
     };
-  }, [dispatch,showingLoginModal]);
+  }, [dispatch, showingLoginModal]);
 
   const handleAdultChange = (delta: number) => {
     const newAdults = Math.max(1, adults + delta);
@@ -112,12 +112,12 @@ const LodgeDetailPage = () => {
   };
 
   useEffect(() => {
-    if(isLoading) {
-      dispatch(showLoading())
+    if (isLoading) {
+      dispatch(showLoading());
     } else {
       dispatch(hideLoading());
     }
-  }, [isLoading, dispatch])
+  }, [isLoading, dispatch]);
 
   useEffect(() => {
     let checkInStr = searchParams.get("checkIn") ?? "";
@@ -194,7 +194,7 @@ const LodgeDetailPage = () => {
       checkOut,
       adults,
       children,
-      roomCount : room,
+      roomCount: room,
       lodgeName: lodge?.name || "Unknown Lodge",
       roomName,
     };
@@ -218,7 +218,7 @@ const LodgeDetailPage = () => {
 
   const handleBookmarkToggle = async () => {
     if (!isAuthenticated) {
-      dispatch(openLoginModal("bookmark"));
+      dispatch(openLoginModal("lodge/bookmark"));
       return;
     }
     try {
@@ -535,16 +535,16 @@ const LodgeDetailPage = () => {
 
       {showingLoginModal && (
         <div
-        onClick={() => dispatch(closeLoginModal())}
+          onClick={() => dispatch(closeLoginModal())}
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
         >
           <div onClick={(e) => e.stopPropagation()}>
             <LoginPromptModal
               isOpen={showingLoginModal}
               context={loginModalContext}
-            onLogin={() => router.push("/login")}
-          />
-        </div>
+              onLogin={() => router.push("/login")}
+            />
+          </div>
         </div>
       )}
 

--- a/src/app/lodge/[lodgeId]/page.tsx
+++ b/src/app/lodge/[lodgeId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ReviewCard from "@/components/ui/ReviewCard";
+import ReviewCard, { GenericReview } from "@/components/ui/ReviewCard";
 import { closeLoginModal, openLoginModal } from "@/lib/auth/authSlice";
 import {
   useCreateBookmarkMutation,
@@ -236,14 +236,14 @@ const LodgeDetailPage = () => {
     setOpenMenuId((prevId) => (prevId === id ? null : id));
   };
 
-  const startEditing = (review: Review) => {
+  const startEditing = (review: GenericReview) => {
     setEditingId(String(review.id));
     setEditingComment(review.comment || "");
     setEditingRating(review.rating || null);
     setOpenMenuId(null);
   };
 
-  const saveEdit = async (review: Review) => {
+  const saveEdit = async (review: GenericReview) => {
     try {
       await updateReview({
         id: review.id,
@@ -256,7 +256,7 @@ const LodgeDetailPage = () => {
     }
   };
 
-  const handleDelete = async (review: Review) => {
+  const handleDelete = async (review: GenericReview) => {
     if (confirm("Are you sure you want to delete this review?")) {
       try {
         await deleteReview(review.id).unwrap();

--- a/src/app/ticket/[ticketId]/page.tsx
+++ b/src/app/ticket/[ticketId]/page.tsx
@@ -11,11 +11,6 @@ import {
   useUpdateTicketReviewMutation,
   useDeleteTicketReviewMutation,
 } from "@/lib/ticket/ticketApi";
-import {
-  useGetMyBookmarksQuery,
-  useCreateBookmarkMutation,
-  useDeleteBookmarkMutation,
-} from "@/lib/bookmark/bookmarkApi";
 import { openLoginModal, closeLoginModal } from "@/lib/auth/authSlice";
 import { hideLoading, showLoading } from "@/lib/store/loadingSlice";
 import { Heart, HeartOff } from "lucide-react";
@@ -63,6 +58,7 @@ const TicketDetailPage = () => {
   const { data: myBookmarks } = useGetMyTicketBookmarksQuery(undefined, {
     skip: !isAuthenticated,
   });
+
   const [createBookmark] = useCreateTicketBookmarkMutation();
   const [deleteBookmark] = useDeleteTicketBookmarkMutation();
 
@@ -94,7 +90,7 @@ const TicketDetailPage = () => {
 
   const handleBookmarkToggle = async () => {
     if (!isAuthenticated) {
-      dispatch(openLoginModal("bookmark"));
+      dispatch(openLoginModal("ticket/bookmark"));
       return;
     }
     try {
@@ -109,10 +105,6 @@ const TicketDetailPage = () => {
   };
 
   const handleSubmitReview = async () => {
-    if (!isAuthenticated) {
-      dispatch(openLoginModal("review"));
-      return;
-    }
     if (!reviewComment.trim() || reviewRating < 1) {
       alert("내용과 평점을 입력해주세요.");
       return;
@@ -201,6 +193,25 @@ const TicketDetailPage = () => {
             No image available
           </div>
         )}
+      </div>
+
+      <div className="flex items-center gap-2 mb-4">
+        <h1 className="text-3xl font-bold text-primary-900">{ticket.name}</h1>
+        <button
+          onClick={handleBookmarkToggle}
+          className={`text-2xl ${
+            isBookmarked ? "text-red-500" : "text-gray-400"
+          } hover:text-red-600`}
+          aria-label={
+            isBookmarked ? "Remove from favorites" : "Add to favorites"
+          }
+        >
+          {isBookmarked ? (
+            <Heart fill="red" stroke="red" className="w-6 h-6" />
+          ) : (
+            <HeartOff className="w-6 h-6 text-gray-400" />
+          )}
+        </button>
       </div>
 
       <div className="mt-8 border-t pt-6">

--- a/src/components/ui/LoginPromptModal.tsx
+++ b/src/components/ui/LoginPromptModal.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 interface LoginPromptModalProps {
   isOpen: boolean;
-  context: string | null;
+  context: "lodge/bookmark" | "lodge/reserve" | "ticket/bookmark" | null;
   onLogin: () => void;
 }
 
@@ -15,12 +15,19 @@ export default function LoginPromptModal({
 }: LoginPromptModalProps) {
   if (!isOpen) return null;
 
+  const contextMessages: Record<
+    NonNullable<LoginPromptModalProps["context"]>,
+    string
+  > = {
+    "lodge/reserve": "로그인 후 숙소 예약을 완료할 수 있어요.",
+    "lodge/bookmark": "로그인 후 이 숙소를 찜할 수 있어요.",
+    "ticket/bookmark": "로그인 후 이 티켓을 찜할 수 있어요.",
+  };
+
   return (
-    <div
-    className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full gap-5 flex flex-col items-center">
+    <div className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full gap-5 flex flex-col items-center">
       <p className="text-primary-900 text-lg font-medium">
-        {context === "reserve" && "로그인 후 숙소 예약을 완료할 수 있어요."}
-        {context === "bookmark" && "로그인 후 이 숙소를 찜할 수 있어요."}
+        {context ? contextMessages[context] : ""}
       </p>
       <button
         className="bg-primary-700 text-white rounded-md px-3 py-1 hover:bg-primary-500"

--- a/src/lib/auth/authSlice.ts
+++ b/src/lib/auth/authSlice.ts
@@ -1,6 +1,11 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
+export type LoginModalContextType =
+  | "lodge/bookmark"
+  | "lodge/reserve"
+  | "ticket/bookmark";
+
 interface User {
   id: number;
   nickname: string;
@@ -14,15 +19,15 @@ interface AuthState {
   isAuthenticated: boolean;
   accessToken: string | null;
   showingLoginModal: boolean;
-  loginModalContext: string | null;
+  loginModalContext: LoginModalContextType | null;
 }
 
 const initialState: AuthState = {
   user: undefined,
   isAuthenticated: false,
   accessToken: null,
-  showingLoginModal:false,
-  loginModalContext:null
+  showingLoginModal: false,
+  loginModalContext: null,
 };
 
 const authSlice = createSlice({
@@ -60,7 +65,10 @@ const authSlice = createSlice({
         localStorage.removeItem("accessToken");
       }
     },
-    openLoginModal: (state, action: PayloadAction<string | null>) => {
+    openLoginModal: (
+      state,
+      action: PayloadAction<LoginModalContextType | null>
+    ) => {
       state.showingLoginModal = true;
       state.loginModalContext = action.payload;
     },
@@ -68,14 +76,21 @@ const authSlice = createSlice({
       state.showingLoginModal = false;
       state.loginModalContext = null;
     },
-    updateNickname(state,action) {
-      if(state.user) {
+    updateNickname(state, action) {
+      if (state.user) {
         state.user.nickname = action.payload;
       }
-    }
+    },
   },
 });
 
-export const { logout, setUserOnly, setCredential, setAccessToken, openLoginModal, closeLoginModal, updateNickname } =
-  authSlice.actions;
+export const {
+  logout,
+  setUserOnly,
+  setCredential,
+  setAccessToken,
+  openLoginModal,
+  closeLoginModal,
+  updateNickname,
+} = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
# Pull Request

## Description  
- Added bookmark toggle button to `ticket/[ticketId]/page.tsx`, enabling users to bookmark (or un-bookmark) tickets.
- Refactored `LoginPromptModal.tsx` to support both lodge and ticket pages.  
  - Context now accepts `"lodge/bookmark"`, `"lodge/reserve"`, `"ticket/bookmark"` for more descriptive login prompts.
  - This makes the modal reusable between `lodge/[lodgeId]/page.tsx` and `ticket/[ticketId]/page.tsx`.


## Why  
- Users should be able to save/bookmark tickets they’re interested in.
- Needed to share the same login modal between LodgeDetailPage and TicketDetailPage while showing accurate context-specific messages.
- Improves consistency, code reuse, and maintainability.

## Testing  
- Ran app locally.
- Verified:
  - Ticket detail page shows bookmark heart icon (toggles on/off, reflects user’s bookmarks).
  - Lodge detail page bookmark button remains functional.
  - Login modal correctly shows context-specific messages depending on where it’s triggered:
    - “로그인 후 이 숙소를 찜할 수 있어요.”
    - “로그인 후 이 티켓을 찜할 수 있어요.”
    - “로그인 후 숙소 예약을 완료할 수 있어요.”

## Linked Issues  
Fixes #69 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
