### PR TITLE
Feat/ticket

### DIFF
--- a/src/app/profile/reservations/TicketReservationCard.tsx
+++ b/src/app/profile/reservations/TicketReservationCard.tsx
@@ -1,0 +1,59 @@
+import { TicketReservation } from "@/types/ticketReservation";
+import React from "react";
+
+interface TicketReservationCardProps {
+  ticket: TicketReservation;
+}
+
+const TicketReservationCard: React.FC<TicketReservationCardProps> = ({
+  ticket,
+}) => {
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "CONFIRMED":
+        return (
+          <span className="px-3 py-1 rounded border bg-green-600 text-white text-xs font-semibold">
+            예약확정
+          </span>
+        );
+      case "PENDING":
+        return (
+          <span className="px-3 py-1 rounded border bg-yellow-500 text-white text-xs font-semibold">
+            진행중
+          </span>
+        );
+      case "CANCELLED":
+        return (
+          <span className="px-3 py-1 rounded border bg-red-600 text-white text-xs font-semibold">
+            예약취소
+          </span>
+        );
+      default:
+        return (
+          <span className="px-3 py-1 rounded border text-gray-700 border-gray-700 text-xs font-semibold">
+            상태 없음
+          </span>
+        );
+    }
+  };
+
+  return (
+    <div className="border rounded p-4 shadow hover:shadow-lg transition">
+      <div className="flex justify-between items-center mb-3">
+        <h2 className="text-lg font-semibold mb-2">
+          {ticket.ticketType?.name || "이름 없는 티켓"}
+        </h2>
+        {getStatusBadge(ticket.status)}
+      </div>
+      <p className="text-sm text-gray-700 mb-1">날짜: {ticket.date.slice(0, 10)}</p>
+      <p className="text-sm text-gray-700 mb-1">
+        성인: {ticket.adults}명, 어린이: {ticket.children}명
+      </p>
+      <p className="text-sm text-gray-500">
+        예약일: {new Date(ticket.createdAt).toLocaleString()}
+      </p>
+    </div>
+  );
+};
+
+export default TicketReservationCard;

--- a/src/app/profile/reservations/TicketReservationCard.tsx
+++ b/src/app/profile/reservations/TicketReservationCard.tsx
@@ -3,10 +3,12 @@ import React from "react";
 
 interface TicketReservationCardProps {
   ticket: TicketReservation;
+  onClick?: (ticket: TicketReservation) => void;
 }
 
 const TicketReservationCard: React.FC<TicketReservationCardProps> = ({
   ticket,
+  onClick,
 }) => {
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -38,14 +40,19 @@ const TicketReservationCard: React.FC<TicketReservationCardProps> = ({
   };
 
   return (
-    <div className="border rounded p-4 shadow hover:shadow-lg transition">
+    <div
+      onClick={() => onClick?.(ticket)}
+      className="border rounded p-4 shadow hover:shadow-lg transition cursor-pointer"
+    >
       <div className="flex justify-between items-center mb-3">
         <h2 className="text-lg font-semibold mb-2">
           {ticket.ticketType?.name || "이름 없는 티켓"}
         </h2>
         {getStatusBadge(ticket.status)}
       </div>
-      <p className="text-sm text-gray-700 mb-1">날짜: {ticket.date.slice(0, 10)}</p>
+      <p className="text-sm text-gray-700 mb-1">
+        날짜: {ticket.date.slice(0, 10)}
+      </p>
       <p className="text-sm text-gray-700 mb-1">
         성인: {ticket.adults}명, 어린이: {ticket.children}명
       </p>

--- a/src/app/profile/reservations/page.tsx
+++ b/src/app/profile/reservations/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import ReservationCard from "./ReservationCard";
 import { fetchTicketReservations } from "@/lib/ticket-reservation/ticketReservationThunk";
 import TicketReservationCard from "./TicketReservationCard";
+import { TicketReservation } from "@/types/ticketReservation";
 
 export default function ReservationListPage() {
   const [showingModal, setShowingModal] = useState(false);
@@ -24,6 +25,9 @@ export default function ReservationListPage() {
   const [ticketFilter, setTicketFilter] = useState<
     "ALL" | "PENDING" | "CONFIRMED" | "CANCELLED"
   >("ALL");
+  const [ticketModalOpen, setTicketModalOpen] = useState(false);
+  const [selectedTicket, setSelectedTicket] =
+    useState<TicketReservation | null>(null);
 
   const dispatch = useAppDispatch();
   const { list, loading, error } = useAppSelector((state) => state.reservation);
@@ -83,6 +87,11 @@ export default function ReservationListPage() {
     ticketFilter === "ALL"
       ? ticketState.list
       : ticketState.list.filter((t) => t.status === ticketFilter);
+
+  const openTicketModal = (ticket: TicketReservation) => {
+    setSelectedTicket(ticket);
+    setTicketModalOpen(true);
+  };
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
@@ -229,7 +238,11 @@ export default function ReservationListPage() {
           {!ticketState.loading && filteredTicketList.length > 0 && (
             <div className="space-y-4">
               {filteredTicketList.map((ticket) => (
-                <TicketReservationCard key={ticket.id} ticket={ticket} />
+                <TicketReservationCard
+                  key={ticket.id}
+                  ticket={ticket}
+                  onClick={openTicketModal}
+                />
               ))}
             </div>
           )}
@@ -336,6 +349,45 @@ export default function ReservationListPage() {
             </div>
           </div>
         </>
+      )}
+
+      {ticketModalOpen && selectedTicket && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-sm mx-auto">
+            <h2 className="text-lg font-semibold mb-4">티켓 예약 상세 정보</h2>
+
+            <p className="mb-2">
+              <strong>티켓명:</strong>{" "}
+              {selectedTicket.ticketType?.name || "정보 없음"}
+            </p>
+            <p className="mb-2">
+              <strong>이용일:</strong> {selectedTicket.date.slice(0, 10)}
+            </p>
+            <p className="mb-2">
+              <strong>성인:</strong> {selectedTicket.adults}명
+            </p>
+            <p className="mb-2">
+              <strong>어린이:</strong> {selectedTicket.children}명
+            </p>
+            <p className="mb-2">
+              <strong>총 가격:</strong>{" "}
+              {selectedTicket.totalPrice?.toLocaleString() || "계산 안됨"}원
+            </p>
+            <p className="mb-2">
+              <strong>예약일:</strong>{" "}
+              {new Date(selectedTicket.createdAt).toLocaleString()}
+            </p>
+
+            <div className="mt-4 flex justify-end">
+              <button
+                className="bg-primary-700 text-white px-4 py-2 rounded hover:bg-primary-800"
+                onClick={() => setTicketModalOpen(false)}
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {showCancelModal && (

--- a/src/app/profile/reservations/page.tsx
+++ b/src/app/profile/reservations/page.tsx
@@ -20,6 +20,9 @@ export default function ReservationListPage() {
   const [agreeRefundPolicy, setAgreeRefundPolicy] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [typeFilter, setTypeFilter] = useState<"LODGING" | "TICKET">("LODGING");
+  const [ticketFilter, setTicketFilter] = useState<
+    "ALL" | "PENDING" | "CONFIRMED" | "CANCELLED"
+  >("ALL");
 
   const dispatch = useAppDispatch();
   const { list, loading, error } = useAppSelector((state) => state.reservation);
@@ -74,6 +77,11 @@ export default function ReservationListPage() {
     filter === "ALL" ? list : list.filter((r) => r.status === filter);
 
   const formatDate = (date: Date) => date.toISOString().slice(0, 10);
+
+  const filteredTicketList =
+    ticketFilter === "ALL"
+      ? ticketState.list
+      : ticketState.list.filter((t) => t.status === ticketFilter);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
@@ -168,18 +176,58 @@ export default function ReservationListPage() {
         </>
       ) : (
         <>
-          {ticketState.loading && (
-            <p className="text-gray-600">불러오는 중...</p>
+          <div className="flex flex-wrap gap-2 mb-6">
+            <button
+              onClick={() => setTicketFilter("ALL")}
+              className={`px-3 py-1 rounded border ${
+                ticketFilter === "ALL"
+                  ? "bg-primary-700 text-white"
+                  : "text-primary-800 border-primary-700 hover:bg-primary-700 hover:text-white"
+              }`}
+            >
+              전체
+            </button>
+            <button
+              onClick={() => setTicketFilter("PENDING")}
+              className={`px-3 py-1 rounded border ${
+                ticketFilter === "PENDING"
+                  ? "bg-yellow-500 text-white"
+                  : "text-yellow-700 border-yellow-700 hover:bg-yellow-700 hover:text-white"
+              }`}
+            >
+              진행중
+            </button>
+            <button
+              onClick={() => setTicketFilter("CONFIRMED")}
+              className={`px-3 py-1 rounded border ${
+                ticketFilter === "CONFIRMED"
+                  ? "bg-green-600 text-white"
+                  : "text-green-700 border-green-700 hover:bg-green-700 hover:text-white"
+              }`}
+            >
+              예약확정
+            </button>
+            <button
+              onClick={() => setTicketFilter("CANCELLED")}
+              className={`px-3 py-1 rounded border ${
+                ticketFilter === "CANCELLED"
+                  ? "bg-red-600 text-white"
+                  : "text-red-700 border-red-700 hover:bg-red-700 hover:text-white"
+              }`}
+            >
+              예약취소
+            </button>
+          </div>
+
+          {!ticketState.loading && filteredTicketList.length === 0 && (
+            <p className="text-gray-700">
+              해당 조건의 티켓 예약 내역이 없습니다.
+            </p>
           )}
-          {ticketState.error && (
-            <p className="text-red-500">{ticketState.error}</p>
-          )}
-          {!ticketState.loading && ticketState.list.length === 0 && (
-            <p className="text-gray-700">티켓 예약 내역이 없습니다.</p>
-          )}
-          {!ticketState.loading && ticketState.list.length > 0 && (
+
+          {!ticketState.loading && filteredTicketList.length > 0 && (
             <div className="space-y-4">
-              {ticketState.list.map((ticket) => (
+              {filteredTicketList.map((ticket) => (
                 <div
                   key={ticket.id}
                   className="border border-gray-300 rounded p-4 shadow-sm"

--- a/src/app/profile/reservations/page.tsx
+++ b/src/app/profile/reservations/page.tsx
@@ -9,6 +9,7 @@ import {
 import Link from "next/link";
 import ReservationCard from "./ReservationCard";
 import { fetchTicketReservations } from "@/lib/ticket-reservation/ticketReservationThunk";
+import TicketReservationCard from "./TicketReservationCard";
 
 export default function ReservationListPage() {
   const [showingModal, setShowingModal] = useState(false);
@@ -228,41 +229,7 @@ export default function ReservationListPage() {
           {!ticketState.loading && filteredTicketList.length > 0 && (
             <div className="space-y-4">
               {filteredTicketList.map((ticket) => (
-                <div
-                  key={ticket.id}
-                  className="relative border border-gray-300 rounded p-4 shadow-sm"
-                >
-                  <span
-                    className={`absolute top-2 right-2 text-xs font-bold px-2 py-1 rounded ${
-                      ticket.status === "PENDING"
-                        ? "bg-yellow-400 text-yellow-900"
-                        : ticket.status === "CONFIRMED"
-                        ? "bg-green-500 text-white"
-                        : ticket.status === "CANCELLED"
-                        ? "bg-red-500 text-white"
-                        : "bg-gray-300 text-gray-700"
-                    }`}
-                  >
-                    {ticket.status === "PENDING"
-                      ? "진행중"
-                      : ticket.status === "CONFIRMED"
-                      ? "예약확정"
-                      : ticket.status === "CANCELLED"
-                      ? "예약취소"
-                      : ticket.status}
-                  </span>
-                  <p className="font-semibold text-lg">
-                    {ticket.ticketType?.name}
-                  </p>
-                  <p>날짜: {ticket.date}</p>
-                  <p>
-                    성인: {ticket.adults}명, 어린이: {ticket.children}명
-                  </p>
-                  <p>예약 상태: {ticket.status}</p>
-                  <p className="text-sm text-gray-500">
-                    예약일: {new Date(ticket.createdAt).toLocaleString()}
-                  </p>
-                </div>
+                <TicketReservationCard key={ticket.id} ticket={ticket} />
               ))}
             </div>
           )}

--- a/src/app/profile/reservations/page.tsx
+++ b/src/app/profile/reservations/page.tsx
@@ -230,8 +230,27 @@ export default function ReservationListPage() {
               {filteredTicketList.map((ticket) => (
                 <div
                   key={ticket.id}
-                  className="border border-gray-300 rounded p-4 shadow-sm"
+                  className="relative border border-gray-300 rounded p-4 shadow-sm"
                 >
+                  <span
+                    className={`absolute top-2 right-2 text-xs font-bold px-2 py-1 rounded ${
+                      ticket.status === "PENDING"
+                        ? "bg-yellow-400 text-yellow-900"
+                        : ticket.status === "CONFIRMED"
+                        ? "bg-green-500 text-white"
+                        : ticket.status === "CANCELLED"
+                        ? "bg-red-500 text-white"
+                        : "bg-gray-300 text-gray-700"
+                    }`}
+                  >
+                    {ticket.status === "PENDING"
+                      ? "진행중"
+                      : ticket.status === "CONFIRMED"
+                      ? "예약확정"
+                      : ticket.status === "CANCELLED"
+                      ? "예약취소"
+                      : ticket.status}
+                  </span>
                   <p className="font-semibold text-lg">
                     {ticket.ticketType?.name}
                   </p>


### PR DESCRIPTION
# Pull Request

## Description  
- Added "숙소 예약" and "티켓 예약" toggle buttons in profile/reservations/page.tsx for filtering reservation types
- Implemented TicketReservationCard.tsx to display individual ticket reservation entries
- Imported and used TicketReservationCard in page.tsx to display ticket reservation lists
- Created ticket detail modal UI for showing ticket reservation info
- Added handleTicketCancel logic to allow users to cancel confirmed ticket reservations with UI feedback and state updates

## Why  
These changes enhance the reservation management page to support both lodging and ticket reservations, giving users a seamless experience to view and manage all their bookings in one place. The new modal provides a clean and detailed view of each ticket reservation and introduces cancellation functionality for better user control.

## Testing  
- Ran the app locally and navigated to /profile/reservations
- Verified that clicking "숙소 예약" or "티켓 예약" correctly filters reservation lists
- Confirmed that ticket reservation cards render correctly
- Clicked on a ticket card to open the modal and verified all reservation details are shown
- Tested the cancel flow: cancel button appears only for confirmed reservations, and clicking it properly updates state and UI

## Linked Issues  
fixes #36 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [x] Component or util func created  
- [x] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
