### PR TITLE
Feat/reviews

### DIFF
--- a/src/app/profile/reviews/LodgeReview.tsx
+++ b/src/app/profile/reviews/LodgeReview.tsx
@@ -18,12 +18,21 @@ import { formattedDate } from "@/utils/date";
 
 const LodgeReview = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [page, setPage] = useState(1);
+  const pageSize = 5;
 
   const dispatch = useAppDispatch();
   const nickname = useAppSelector((state) => state.auth.user?.nickname);
-  const reservation = useAppSelector((state) => state.reservation.list);
 
-  const { data: reviews, isLoading, isError } = useGetReviewsByUserIdQuery();
+  const { data, isLoading, isError } = useGetReviewsByUserIdQuery({
+    page,
+    pageSize,
+  });
+
+  const reviews = data?.reviews || [];
+  const totalCount = data?.totalCount || 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
+
   const [deleteReview] = useDeleteReviewMutation();
   const [updateReview] = useUpdateReviewMutation();
 
@@ -188,6 +197,26 @@ const LodgeReview = () => {
             )}
           </li>
         ))}
+
+        <div className="mt-4 flex gap-2">
+          <button
+            onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+            disabled={page === 1}
+            className="px-3 py-1 bg-gray-200 rounded"
+          >
+            Prev
+          </button>
+          <span className="px-2 py-1">
+            Page {page} of {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+            disabled={page === totalPages}
+            className="px-3 py-1 bg-gray-200 rounded"
+          >
+            Next
+          </button>
+        </div>
       </ul>
     </div>
   );

--- a/src/app/profile/reviews/LodgeReview.tsx
+++ b/src/app/profile/reviews/LodgeReview.tsx
@@ -198,7 +198,7 @@ const LodgeReview = () => {
           </li>
         ))}
 
-        <div className="mt-4 flex gap-2">
+        <div className="mt-4 flex gap-2 justify-center items-center">
           <button
             onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
             disabled={page === 1}

--- a/src/app/profile/reviews/LodgeReviewCreateModal.tsx
+++ b/src/app/profile/reviews/LodgeReviewCreateModal.tsx
@@ -20,7 +20,7 @@ const LodgeReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const [createReview] = useCreateReviewMutation();
   const reservationList = useAppSelector((state) => state.reservation.list);
 
-  const { data: myReviews } = useGetReviewsByUserIdQuery();
+  const { data: myReviews } = useGetReviewsByUserIdQuery({ page: 1, pageSize: 100 });
   const reviewedReservationIds = new Set(
     (myReviews as Review[])?.map((r) => r.reservationId)
   );

--- a/src/app/profile/reviews/TicketReview.tsx
+++ b/src/app/profile/reviews/TicketReview.tsx
@@ -8,11 +8,11 @@ import {
   useUpdateTicketReviewMutation,
 } from "@/lib/ticket-review/ticketReviewApi";
 import { MoreVertical } from "lucide-react";
-import TicketReviewCreateModal from "./TicketReviewCreateModal";
 import { Rating } from "@smastrom/react-rating";
 import "@smastrom/react-rating/style.css";
 import { formattedDate } from "@/utils/date";
 import type { TicketReview } from "@/types/ticketReview";
+import TicketReviewCreateModal from "./TicketReviewCreateModal";
 
 const TicketReview = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/app/profile/reviews/TicketReview.tsx
+++ b/src/app/profile/reviews/TicketReview.tsx
@@ -16,9 +16,14 @@ import TicketReviewCreateModal from "./TicketReviewCreateModal";
 
 const TicketReview = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [page, setPage] = useState(1);
+  const pageSize = 5;
 
   const nickname = useAppSelector((state) => state.auth.user?.nickname);
-  const { data: reviews, isLoading, isError } = useGetMyTicketReviewsQuery();
+  const { data, isLoading, isError } = useGetMyTicketReviewsQuery({
+    page,
+    pageSize,
+  });
   const [deleteReview] = useDeleteTicketReviewMutation();
   const [updateReview] = useUpdateTicketReviewMutation();
 
@@ -26,6 +31,10 @@ const TicketReview = () => {
   const [editingComment, setEditingComment] = useState("");
   const [editingRating, setEditingRating] = useState<number | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+
+  const reviews = data?.reviews || [];
+  const totalCount = data?.totalCount || 0;
+  const totalPages = Math.ceil(totalCount / pageSize);
 
   const toggleMenu = (id: string) => {
     setOpenMenuId((prevId) => (prevId === id ? null : id));
@@ -172,6 +181,28 @@ const TicketReview = () => {
             )}
           </li>
         ))}
+
+        {totalPages > 1 && (
+          <div className="mt-4 flex gap-2 justify-center items-center">
+            <button
+              onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+              disabled={page === 1}
+              className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50"
+            >
+              Prev
+            </button>
+            <span className="px-2">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((prev) => Math.min(prev + 1, totalPages))}
+              disabled={page === totalPages}
+              className="px-3 py-1 bg-gray-200 rounded disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        )}
       </ul>
     </div>
   );

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -22,7 +22,10 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const [createReview] = useCreateTicketReviewMutation();
   const tickets = useAppSelector((state) => state.ticketReservation.list);
 
-  const { data: myReviews } = useGetMyTicketReviewsQuery();
+  const { data: myReviews } = useGetMyTicketReviewsQuery({
+    page: 1,
+    pageSize: 100,
+  });
 
   const reviewedReservationIds = new Set(
     (myReviews as TicketReview[])?.map((r) => r.ticketReservation.id)

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -23,12 +23,9 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const tickets = useAppSelector((state) => state.ticketReservation.list);
 
   const { data: myReviews } = useGetMyTicketReviewsQuery();
-  const reviewedTicketTypeIds = new Set(
-    (myReviews as TicketReview[])?.map((r) => r.ticketTypeId)
-  );
 
   const reviewedReservationIds = new Set(
-    (myReviews as TicketReview[])?.map((r) => r.ticketReservationId)
+    (myReviews as TicketReview[])?.map((r) => r.ticketReservation.id)
   );
 
   const [ticketTypeId, setTicketTypeId] = useState<number | null>(null);

--- a/src/lib/review/reviewApi.ts
+++ b/src/lib/review/reviewApi.ts
@@ -11,13 +11,18 @@ export const reviewApi = createApi({
   tagTypes: ["Reviews"],
   endpoints: (builder) => ({
     getReviewsByLodgeId: builder.query({
-      query: (lodgeId) => `review/lodge/${lodgeId}`,
+      query: ({ lodgeId, page = 1, pageSize = 5 }) =>
+        `review/lodge/${lodgeId}?page=${page}&pageSize=${pageSize}`,
       providesTags: (result, error, lodgeId) => [
         { type: "Reviews", id: lodgeId },
       ],
     }),
-    getReviewsByUserId: builder.query<any, void>({
-      query: () => `review/my`,
+    getReviewsByUserId: builder.query<
+      any,
+      { page?: number; pageSize?: number }
+    >({
+      query: ({ page = 1, pageSize = 5 }) =>
+        `review/my?page=${page}&pageSize=${pageSize}`,
       providesTags: ["Reviews"],
     }),
     createReview: builder.mutation({

--- a/src/lib/ticket-review/ticketReviewApi.ts
+++ b/src/lib/ticket-review/ticketReviewApi.ts
@@ -10,15 +10,23 @@ export const ticketReviewApi = createApi({
   }),
   tagTypes: ["TicketReviews"],
   endpoints: (builder) => ({
-    getReviewsByTicketTypeId: builder.query({
-      query: (ticketTypeId) => `ticket-review/ticket/${ticketTypeId}`,
-      providesTags: (result, error, ticketTypeId) => [
+    getReviewsByTicketTypeId: builder.query<
+      any,
+      { ticketTypeId: number; page?: number; pageSize?: number }
+    >({
+      query: ({ ticketTypeId, page = 1, pageSize = 5 }) =>
+        `ticket-review/ticket/${ticketTypeId}?page=${page}&pageSize=${pageSize}`,
+      providesTags: (result, error, { ticketTypeId }) => [
         { type: "TicketReviews", id: ticketTypeId },
       ],
     }),
 
-    getMyTicketReviews: builder.query<any, void>({
-      query: () => `ticket-review/my`,
+    getMyTicketReviews: builder.query<
+      any,
+      { page?: number; pageSize?: number }
+    >({
+      query: ({ page = 1, pageSize = 5 }) =>
+        `ticket-review/my?page=${page}&pageSize=${pageSize}`,
       providesTags: ["TicketReviews"],
     }),
 


### PR DESCRIPTION
# Pull Request

## Description  
- Added pagination support to frontend review-related APIs:
  - Updated getReviewsByUserId in reviewApi.ts to accept page and pageSize
  - Updated getMyTicketReviews in ticketReviewApi.ts to accept page and pageSize
- Implemented pagination UI in both:
  - LodgeReview.tsx (숙소 리뷰)
  - TicketReview.tsx (티켓 리뷰)
- Added Prev / Next buttons with page state management using useState
- Used totalCount returned from backend to calculate totalPages and control pagination range

## Why  
This enables paginated data loading for user-generated reviews, reducing frontend memory usage and improving performance when users have many reviews. It also aligns with the updated backend pagination functionality for both lodge and ticket reviews.

## Testing  
- Verified correct query behavior by calling useGetReviewsByUserIdQuery({ page, pageSize }) and useGetMyTicketReviewsQuery({ page, pageSize })
- Navigated between pages using Prev/Next buttons in LodgeReview.tsx and TicketReview.tsx
- Checked that the correct page of reviews loads from backend and UI updates accordingly
- Confirmed empty state messages appear when there are no reviews

## Linked Issues  
Fixes #85 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
