### PR TITLE
Feat/reviews

### DIFF
--- a/src/app/profile/reviews/LodgeReviewCreateModal.tsx
+++ b/src/app/profile/reviews/LodgeReviewCreateModal.tsx
@@ -20,9 +20,13 @@ const LodgeReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const [createReview] = useCreateReviewMutation();
   const reservationList = useAppSelector((state) => state.reservation.list);
 
-  const { data: myReviews } = useGetReviewsByUserIdQuery({ page: 1, pageSize: 100 });
-  const reviewedReservationIds = new Set(
-    (myReviews as Review[])?.map((r) => r.reservationId)
+  const { data: myReviews } = useGetReviewsByUserIdQuery({
+    page: 1,
+    pageSize: 100,
+  });
+
+  const reviewedReservationIds = new Set<number>(
+    (myReviews?.reviews ?? []).map((r: Review) => r.reservationId)
   );
 
   const [lodgeId, setLodgeId] = useState<number | null>(null);

--- a/src/app/profile/reviews/TicketReview.tsx
+++ b/src/app/profile/reviews/TicketReview.tsx
@@ -20,7 +20,7 @@ const TicketReview = () => {
   const pageSize = 5;
 
   const nickname = useAppSelector((state) => state.auth.user?.nickname);
-  const { data, isLoading, isError } = useGetMyTicketReviewsQuery({
+  const { data, isLoading, isError, refetch } = useGetMyTicketReviewsQuery({
     page,
     pageSize,
   });
@@ -63,6 +63,8 @@ const TicketReview = () => {
         },
       }).unwrap();
       cancelEditing();
+      alert("리뷰가 업데이트되었습니다");
+      refetch();
     } catch (error) {
       console.error("Failed to update review:", error);
       alert("Failed to update review");
@@ -74,6 +76,7 @@ const TicketReview = () => {
     try {
       await deleteReview(review.id).unwrap();
       alert("리뷰가 삭제되었습니다");
+      refetch();
     } catch (error) {
       console.error("리뷰 삭제 실패:", error);
       alert("리뷰 삭제 실패");
@@ -96,7 +99,12 @@ const TicketReview = () => {
       )}
 
       {isModalOpen && (
-        <TicketReviewCreateModal onClose={() => setIsModalOpen(false)} />
+        <TicketReviewCreateModal
+          onClose={() => {
+            setIsModalOpen(false);
+            refetch();
+          }}
+        />
       )}
 
       <ul className="space-y-4">

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -49,23 +49,10 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
     todayDateOnly.getDate()
   );
 
-  console.log("All Tickets:", tickets);
-  console.log("Reviewed IDs:", reviewedReservationIds);
-  console.log("Today:", today);
-
-  const entireState = useAppSelector((state) => state);
-  console.log("Redux state:", entireState);
-
   const eligibleTickets = tickets?.filter((t) => {
     const ticketDate = getDateOnly(t.date);
     const isBeforeOrToday = ticketDate <= today;
     const isNotReviewed = !reviewedReservationIds.has(t.id);
-
-    console.log(`Ticket ${t.id} - ${formatDate(t.date)}:`, {
-      ticketDate,
-      isBeforeOrToday,
-      isNotReviewed,
-    });
 
     return isBeforeOrToday && isNotReviewed;
   });

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -25,7 +25,7 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const [createReview] = useCreateTicketReviewMutation();
   const tickets = useAppSelector((state) => state.ticketReservation.list);
 
-  const { data: myReviews } = useGetMyTicketReviewsQuery({
+  const { data: myReviews, refetch } = useGetMyTicketReviewsQuery({
     page: 1,
     pageSize: 100,
   });
@@ -81,6 +81,9 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
         rating,
         ticketReservationId,
       }).unwrap();
+
+      await refetch();
+
       alert("티켓 리뷰가 등록되었습니다.");
       onClose();
     } catch (error) {

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -31,9 +31,9 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   });
 
   const reviewedReservationIds = new Set<number>(
-    ((myReviews?.reviews ?? []) as TicketReview[]).map(
-      (r) => r.ticketReservation.id
-    )
+    ((myReviews?.reviews ?? []) as TicketReview[])
+      .filter((r) => r.ticketReservation?.id != null)
+      .map((r) => r.ticketReservation!.id)
   );
 
   const [ticketTypeId, setTicketTypeId] = useState<number | null>(null);

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -53,6 +53,9 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   console.log("Reviewed IDs:", reviewedReservationIds);
   console.log("Today:", today);
 
+  const entireState = useAppSelector((state) => state);
+  console.log("Redux state:", entireState);
+
   const eligibleTickets = tickets?.filter((t) => {
     const ticketDate = getDateOnly(t.date);
     const isBeforeOrToday = ticketDate <= today;

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -32,8 +32,8 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
 
   const reviewedReservationIds = new Set<number>(
     ((myReviews?.reviews ?? []) as TicketReview[])
-      .filter((r) => r.ticketReservation?.id != null)
-      .map((r) => r.ticketReservation!.id)
+      .filter((r) => r.reservation?.id != null)
+      .map((r) => r.reservation!.id)
   );
 
   const [ticketTypeId, setTicketTypeId] = useState<number | null>(null);

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useAppSelector } from "@/lib/store/hooks";
+import { useEffect, useState } from "react";
+import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import {
   useCreateTicketReviewMutation,
   useGetMyTicketReviewsQuery,
@@ -9,6 +9,7 @@ import {
 import { Rating } from "@smastrom/react-rating";
 import "@smastrom/react-rating/style.css";
 import { TicketReview } from "@/types/ticketReview";
+import { fetchTicketReservations } from "@/lib/ticket-reservation/ticketReservationThunk";
 
 interface Props {
   onClose: () => void;
@@ -18,6 +19,8 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const [ticketReservationId, setTicketReservationId] = useState<number | null>(
     null
   );
+
+  const dispatch = useAppDispatch();
 
   const [createReview] = useCreateTicketReviewMutation();
   const tickets = useAppSelector((state) => state.ticketReservation.list);
@@ -36,6 +39,10 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const [ticketTypeId, setTicketTypeId] = useState<number | null>(null);
   const [comment, setComment] = useState("");
   const [rating, setRating] = useState<number>(0);
+
+  useEffect(() => {
+    dispatch(fetchTicketReservations({ page: 1, status: "CONFIRMED" }));
+  }, [dispatch]);
 
   const getDateOnly = (dateStr: string) => {
     const date = new Date(dateStr);

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -27,23 +27,45 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
     pageSize: 100,
   });
 
-  const reviewedReservationIds = new Set(
-    (myReviews?.reviews as TicketReview[]).map((r) => r.ticketReservation.id)
+  const reviewedReservationIds = new Set<number>(
+    ((myReviews?.reviews ?? []) as TicketReview[]).map(
+      (r) => r.ticketReservation.id
+    )
   );
 
   const [ticketTypeId, setTicketTypeId] = useState<number | null>(null);
   const [comment, setComment] = useState("");
   const [rating, setRating] = useState<number>(0);
 
-  const today = new Date();
+  const getDateOnly = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  };
+
+  const todayDateOnly = new Date();
+  const today = new Date(
+    todayDateOnly.getFullYear(),
+    todayDateOnly.getMonth(),
+    todayDateOnly.getDate()
+  );
+
+  console.log("All Tickets:", tickets);
+  console.log("Reviewed IDs:", reviewedReservationIds);
+  console.log("Today:", today);
 
   const eligibleTickets = tickets?.filter((t) => {
-  const usedDate = new Date(t.date);
-  return (
-    usedDate.toDateString() <= today.toDateString() &&
-    !reviewedReservationIds.has(t.id)
-  );
-});
+    const ticketDate = getDateOnly(t.date);
+    const isBeforeOrToday = ticketDate <= today;
+    const isNotReviewed = !reviewedReservationIds.has(t.id);
+
+    console.log(`Ticket ${t.id} - ${formatDate(t.date)}:`, {
+      ticketDate,
+      isBeforeOrToday,
+      isNotReviewed,
+    });
+
+    return isBeforeOrToday && isNotReviewed;
+  });
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -78,7 +100,12 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
         <label className="block mb-2 font-medium">사용한 티켓</label>
         <select
           value={ticketReservationId ?? ""}
-          onChange={(e) => setTicketReservationId(Number(e.target.value))}
+          onChange={(e) => {
+            const selectedId = Number(e.target.value);
+            const selected = tickets?.find((t) => t.id === selectedId);
+            setTicketReservationId(selectedId);
+            setTicketTypeId(selected?.ticketType.id ?? null);
+          }}
           className="w-full border px-3 py-2 rounded mb-4"
         >
           <option value="">티켓 선택</option>

--- a/src/app/profile/reviews/TicketReviewCreateModal.tsx
+++ b/src/app/profile/reviews/TicketReviewCreateModal.tsx
@@ -28,7 +28,7 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   });
 
   const reviewedReservationIds = new Set(
-    (myReviews as TicketReview[])?.map((r) => r.ticketReservation.id)
+    (myReviews?.reviews as TicketReview[]).map((r) => r.ticketReservation.id)
   );
 
   const [ticketTypeId, setTicketTypeId] = useState<number | null>(null);
@@ -38,9 +38,12 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   const today = new Date();
 
   const eligibleTickets = tickets?.filter((t) => {
-    const usedDate = new Date(t.date);
-    return usedDate <= today && !reviewedReservationIds.has(t.id);
-  });
+  const usedDate = new Date(t.date);
+  return (
+    usedDate.toDateString() <= today.toDateString() &&
+    !reviewedReservationIds.has(t.id)
+  );
+});
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);

--- a/src/types/ticketReview.ts
+++ b/src/types/ticketReview.ts
@@ -11,5 +11,5 @@ export interface TicketReview {
   user: {
     nickname: string;
   };
-  ticketReservation?: TicketReservation | null;
+  reservation?: TicketReservation | null;
 }

--- a/src/types/ticketReview.ts
+++ b/src/types/ticketReview.ts
@@ -11,5 +11,5 @@ export interface TicketReview {
   user: {
     nickname: string;
   };
-  ticketReservation: TicketReservation;
+  ticketReservation?: TicketReservation | null;
 }


### PR DESCRIPTION
# Pull Request

## Description  
- Fixed the logic in TicketReviewCreateModal.tsx to correctly exclude already reviewed reservations from the <select> list.
- Updated the Prisma include in the backend ticket-review.ts API to return the reservation relation so that ticketReservationId comparison works properly in the frontend.
- Implemented refetch() using useGetMyTicketReviewsQuery to ensure newly submitted reviews are reflected immediately in the modal.
- Added safe filtering to avoid runtime errors from missing reservation?.id.

## Why  
This fixes the issue where ticket reservations that had already been reviewed were still appearing in the review modal dropdown. The problem stemmed from missing relation data (reservation) in the review API response, and the fact that the review list wasn't being refreshed after a new review was submitted.

## Testing  
- Ran the app locally
- Created a ticket reservation and wrote a review
- Verified that the reservation disappears from the <select> once the review is submitted
- Verified that reviewedReservationIds correctly tracks submitted reviews
- Confirmed no runtime errors or stale state issues

## Linked Issues  
Fixes #87 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [x] I have reviewed my code for clarity and best practices  
