### PR TITLE
Feat/reviews

### DIFF
--- a/src/app/profile/reviews/TicketReview.tsx
+++ b/src/app/profile/reviews/TicketReview.tsx
@@ -121,6 +121,11 @@ const TicketReview = () => {
                     <span className="text-lg font-semibold mr-3">
                       {review.reservation?.ticketType?.name || "알 수 없음"}
                     </span>
+                    <span className="text-gray-600 ml-1 text-sm">
+                      -{" "}
+                      {review.reservation?.ticketType?.lodge?.name ||
+                        "숙소 없음"}
+                    </span>
                     ({review.reservation?.date?.slice(0, 10) || "알 수 없음"})
                   </p>
                 )}

--- a/src/app/profile/reviews/TicketReview.tsx
+++ b/src/app/profile/reviews/TicketReview.tsx
@@ -116,12 +116,12 @@ const TicketReview = () => {
             <div className="flex justify-between items-start">
               <div>
                 <span className="font-semibold">{review.user?.nickname}</span>
-                {review.ticketReservation && (
+                {review.reservation && (
                   <p className="text-md text-primary-900">
                     <span className="text-lg font-semibold mr-3">
-                      {review.ticketReservation.ticketType.name}
+                      {review.reservation?.ticketType?.name || "알 수 없음"}
                     </span>
-                    ({review.ticketReservation.date.slice(0, 10)})
+                    ({review.reservation?.date?.slice(0, 10) || "알 수 없음"})
                   </p>
                 )}
                 <Rating

--- a/src/types/ticketReservation.ts
+++ b/src/types/ticketReservation.ts
@@ -20,6 +20,9 @@ export interface TicketReservation {
   ticketType: {
     id: number;
     name: string;
+    lodge:{
+      name: string;
+    }
   };
 
   user: {


### PR DESCRIPTION
# Pull Request

## Description  
- Updated ticketReservation.ts type to include lodge.name under ticketType
- Modified TicketReview.tsx to display the lodge name from the nested ticketType.lodge.name inside review.reservation

## Why  
- Previously, the lodge name was shown as “숙소 없음” because ticketType.lodge was not included in the frontend types.
- This change ensures that the lodge name is properly typed and displayed in the user's ticket review list.

## Testing  
- Ran the frontend locally
- Verified that review.reservation.ticketType.lodge.name is correctly shown under each review
- Confirmed that no console errors occurred and fallback UI no longer displays "숙소 없음" unnecessarily

## Linked Issues  
fixes #88 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
