### PR TITLE
Feat/reviews

### DIFF
--- a/src/app/profile/reviews/LodgeReview.tsx
+++ b/src/app/profile/reviews/LodgeReview.tsx
@@ -177,6 +177,14 @@ const LodgeReview = () => {
                   onChange={(e) => setEditingComment(e.target.value)}
                   className="border rounded px-3 py-2"
                 />
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-gray-600">별점 수정:</span>
+                  <Rating
+                    value={editingRating || 0}
+                    onChange={setEditingRating}
+                    style={{ maxWidth: 100 }}
+                  />
+                </div>
                 <div className="flex gap-2">
                   <button
                     onClick={() => saveEdit(review)}

--- a/src/app/profile/reviews/TicketReview.tsx
+++ b/src/app/profile/reviews/TicketReview.tsx
@@ -174,6 +174,11 @@ const TicketReview = () => {
                   onChange={(e) => setEditingComment(e.target.value)}
                   className="border rounded px-3 py-2"
                 />
+                <Rating
+                  value={editingRating ?? 0}
+                  onChange={setEditingRating}
+                  style={{ maxWidth: 100 }}
+                />
                 <div className="flex gap-2">
                   <button
                     onClick={() => saveEdit(review)}

--- a/src/lib/ticket-review/ticketReviewApi.ts
+++ b/src/lib/ticket-review/ticketReviewApi.ts
@@ -42,10 +42,10 @@ export const ticketReviewApi = createApi({
     }),
 
     updateTicketReview: builder.mutation({
-      query: ({ id, ...body }) => ({
-        url: `ticket-review/${id}`,
+      query: ({ reviewId, data }) => ({
+        url: `ticket-review/${reviewId}`,
         method: "PATCH",
-        body,
+        body:data,
       }),
       invalidatesTags: ["TicketReviews"],
     }),


### PR DESCRIPTION
# Pull Request

## Description  
- Fixed ticketReviewApi.ts to ensure the update mutation correctly sends both comment and rating when editing a review.
- Updated TicketReview.tsx to allow editing the star rating (<Rating /> component) alongside the comment.
- Added local state handler for editable rating and integrated the controlled Rating component into the editing UI.

## Why  
These changes allow users to not only update their comment but also modify their rating for a given ticket review.
Previously, only comments could be edited due to limitations in the mutation payload and the edit UI.

## Testing  
- Ran the app locally
- Verified that editing a review opens both a text input for comment and a Rating component
- Edited both rating and comment and confirmed update via UI and DB
- Checked that the updated values persist after refresh (via refetch())

## Linked Issues  
Fixes #89 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
