### PR TITLE
Feat/langs

### DIFF
--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function RedirectHome() {
-  redirect("/en");
+  redirect("/ko");
 }

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,13 +1,13 @@
 import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../lib/store/hooks";
 import { logoutUser } from "../lib/auth/logoutThunk";
 import i18n from "i18next";
 import { useLocale } from "@/utils/useLocale";
 
 const HeaderBar = () => {
-  const [select, setSelect] = useState("en");
+  const [select, setSelect] = useState(i18n.language || "ko");
   const [isHover, setIsHover] = useState(false);
 
   const pathname = usePathname();
@@ -22,6 +22,20 @@ const HeaderBar = () => {
     { name: "English", code: "en" },
     { name: "한국어", code: "ko" },
   ];
+
+  useEffect(() => {
+    const updateLanguage = () => {
+      setSelect(i18n.language);
+    };
+
+    i18n.on("languageChanged", updateLanguage);
+
+    updateLanguage();
+
+    return () => {
+      i18n.off("languageChanged", updateLanguage);
+    };
+  }, []);
 
   const handleLanguageChange = (lang: string) => {
     setSelect(lang);

--- a/src/lib/i18n/TranslationsProvider.tsx
+++ b/src/lib/i18n/TranslationsProvider.tsx
@@ -3,6 +3,7 @@
 import { I18nextProvider } from "react-i18next";
 import { useEffect, useState } from "react";
 import i18n from "./i18n";
+import { useParams } from "next/navigation";
 
 interface Props {
   children: React.ReactNode;
@@ -10,14 +11,17 @@ interface Props {
 
 export default function TranslationsProvider({ children }: Props) {
   const [ready, setReady] = useState(false);
+  const params = useParams();
+  const locale = Array.isArray(params.locale)
+    ? params.locale[0]
+    : params.locale;
 
   useEffect(() => {
-    i18n.on("initialized", () => {
-      setReady(true);
-    });
-
-    if (i18n.isInitialized) setReady(true);
-  }, []);
+    if (i18n.language !== locale) {
+      i18n.changeLanguage(locale);
+    }
+    setReady(true);
+  }, [locale]);
 
   if (!ready) return null;
 

--- a/src/lib/i18n/i18n.ts
+++ b/src/lib/i18n/i18n.ts
@@ -9,8 +9,8 @@ i18n
   .use(Backend)
   .use(initReactI18next)
   .init({
-    lng: "en", // 기본 언어
-    fallbackLng: "en",
+    lng: "ko", // 기본 언어
+    fallbackLng: "ko",
     supportedLngs: ["en", "ko"],
     ns: ["page"],
     defaultNS: "page",

--- a/src/lib/i18n/settings.ts
+++ b/src/lib/i18n/settings.ts
@@ -1,6 +1,6 @@
 const i18nConfig = {
   locales: ["en", "ko"],
-  defaultLocale: "en",
+  defaultLocale: "ko",
 };
 
 export default i18nConfig;


### PR DESCRIPTION
# Pull Request
This pull request introduces changes to support dynamic language switching and updates the default language of the application from English (`en`) to Korean (`ko`). The most important changes include modifying language initialization settings, implementing dynamic language updates based on user interaction, and ensuring language synchronization across components.

### Language Initialization and Default Settings:
* [`src/lib/i18n/i18n.ts`](diffhunk://#diff-f47ee6b1caa9c97a23383c648614e3a675409144311a5330029605613a30fe79L12-R13): Changed the default language (`lng`) and fallback language (`fallbackLng`) from English (`en`) to Korean (`ko`).
* [`src/lib/i18n/settings.ts`](diffhunk://#diff-d5794d7f7d5dd2e0f962aaa8c809baf200e69b65cebc1605678b4a91aa67c5b0L3-R3): Updated the `defaultLocale` in `i18nConfig` from `en` to `ko`.

### Dynamic Language Updates:
* [`src/components/HeaderBar.tsx`](diffhunk://#diff-cf05bc39d5a66db0ba9e554e8fca6e8b74b47a484c2eda7fbaab686611c0e158L3-R10): Added a `useEffect` hook to update the selected language dynamically when the language changes via `i18n.language`. Also updated the initial state of `select` to use the current language or default to `ko`. [[1]](diffhunk://#diff-cf05bc39d5a66db0ba9e554e8fca6e8b74b47a484c2eda7fbaab686611c0e158L3-R10) [[2]](diffhunk://#diff-cf05bc39d5a66db0ba9e554e8fca6e8b74b47a484c2eda7fbaab686611c0e158R26-R39)
* [`src/lib/i18n/TranslationsProvider.tsx`](diffhunk://#diff-c2b95f6b960795cd9c57fb3bef69cbac27686bb4cbad7dd4181e03a2cc4c819eR6-R24): Integrated `useParams` to retrieve the locale from the URL and synchronize it with `i18n.language`. Ensured the application reacts to changes in the locale parameter.

### Routing and Client-Side Behavior:
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL4-R4): Updated the redirect logic to route users to the Korean version of the homepage (`/ko`) instead of English (`/en`).
* `src/app/[locale]/profile/page.tsx`: Added `"use client"` directive to enable client-side rendering for the profile page. ([src/app/[locale]/profile/page.tsxR1-R2](diffhunk://#diff-e1e0960becceaa9b4d84f276ba851f5b57e01a87ac7c6f90a7d27ada98957d1cR1-R2))

## Linked Issues  
Fixes #108 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
