### PR TITLE
Test/build

### DIFF
--- a/src/app/[locale]/admin/lodge/[lodgeId]/page.tsx
+++ b/src/app/[locale]/admin/lodge/[lodgeId]/page.tsx
@@ -1,6 +1,5 @@
-
 "use client";
-export const runtime = 'edge';
+export const runtime = "edge";
 
 import React, { useEffect, useState } from "react";
 import {

--- a/src/app/[locale]/admin/lodge/edit/[lodgeId]/page.tsx
+++ b/src/app/[locale]/admin/lodge/edit/[lodgeId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import LodgeForm from "@/components/ui/LodgeForm";
 import {

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useLocale } from "@/utils/useLocale";
 import Link from "next/link";

--- a/src/app/[locale]/admin/reports/page.tsx
+++ b/src/app/[locale]/admin/reports/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";

--- a/src/app/[locale]/admin/reservations/[id]/page.tsx
+++ b/src/app/[locale]/admin/reservations/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";

--- a/src/app/[locale]/admin/reservations/page.tsx
+++ b/src/app/[locale]/admin/reservations/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";

--- a/src/app/[locale]/admin/reservations/ticket/[id]/page.tsx
+++ b/src/app/[locale]/admin/reservations/ticket/[id]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";

--- a/src/app/[locale]/admin/users/[userId]/page.tsx
+++ b/src/app/[locale]/admin/users/[userId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useParams } from "next/navigation";
 import React, { useEffect, useState } from "react";

--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import React, { useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";

--- a/src/app/[locale]/list/lodge/page.tsx
+++ b/src/app/[locale]/list/lodge/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useGetAvailableLodgeQuery } from "@/lib/lodge/lodgeApi";
 import { useAppDispatch } from "@/lib/store/hooks";

--- a/src/app/[locale]/lodge/[lodgeId]/page.tsx
+++ b/src/app/[locale]/lodge/[lodgeId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import ReviewCard, { GenericReview } from "@/components/ui/ReviewCard";
 import {

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
 import React, { useEffect, useState } from "react";

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import React from "react";
 import Link from "next/link";

--- a/src/app/[locale]/profile/reservations/page.tsx
+++ b/src/app/[locale]/profile/reservations/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";

--- a/src/app/[locale]/profile/reviews/page.tsx
+++ b/src/app/[locale]/profile/reviews/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import React, { useState } from "react";
 import LodgeReview from "../../../../components/reviews/LodgeReview";

--- a/src/app/[locale]/reservation/confirm/page.tsx
+++ b/src/app/[locale]/reservation/confirm/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { createReservation } from "@/lib/reservation/reservationThunk";
 import { useAppDispatch } from "@/lib/store/hooks";

--- a/src/app/[locale]/reservation/fail/page.tsx
+++ b/src/app/[locale]/reservation/fail/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useLocale } from "@/utils/useLocale";
 import { useSearchParams, useRouter } from "next/navigation";

--- a/src/app/[locale]/reservation/page.tsx
+++ b/src/app/[locale]/reservation/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useGetLodgeByIdQuery } from "@/lib/lodge/lodgeApi";
 import { usePriceCalcMutation } from "@/lib/price/priceApi";

--- a/src/app/[locale]/reservation/success/page.tsx
+++ b/src/app/[locale]/reservation/success/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { confirmReservation } from "@/lib/reservation/reservationThunk";
 import { useAppDispatch } from "@/lib/store/hooks";

--- a/src/app/[locale]/reset-password/page.tsx
+++ b/src/app/[locale]/reset-password/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";

--- a/src/app/[locale]/reset-password/verify-reset/page.tsx
+++ b/src/app/[locale]/reset-password/verify-reset/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import {
   updatePassword,

--- a/src/app/[locale]/signup/verify-failed/page.tsx
+++ b/src/app/[locale]/signup/verify-failed/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const runtime = 'edge';
 
 import { useLocale } from "@/utils/useLocale";
 import { useRouter } from "next/navigation";


### PR DESCRIPTION
# Pull Request

This pull request standardizes the runtime environment for various pages in the application by explicitly setting the `runtime` to `"edge"`. The changes ensure consistency across all pages and prepare the application for edge runtime execution.

### Runtime Standardization:

* Added `export const runtime = 'edge';` to the following files to explicitly set the runtime environment:
  - `src/app/[locale]/admin/lodge/edit/[lodgeId]/page.tsx` ([src/app/[locale]/admin/lodge/edit/[lodgeId]/page.tsxR2](diffhunk://#diff-7f503430d097410619fbaf35d1b8d7b7e64a08181c82e32db8848df55a8145c8R2))
  - `src/app/[locale]/admin/page.tsx` ([src/app/[locale]/admin/page.tsxR2](diffhunk://#diff-5c1f2735906943c5ba6dd02878f3515f6e25ef8a8b1601cc1dfee4e8df3682b7R2))
  - `src/app/[locale]/admin/reports/page.tsx` ([src/app/[locale]/admin/reports/page.tsxR2](diffhunk://#diff-a065d25ded840c4d5abd2d8f88062f42194c07048ae721b1f51ecc16ad01922cR2))
  - `src/app/[locale]/admin/reservations/[id]/page.tsx` ([src/app/[locale]/admin/reservations/[id]/page.tsxR2](diffhunk://#diff-c329c7eae43c6b31cc7112e63acd4498e1350b322e0129513526071c4bea868dR2))
  - `src/app/[locale]/admin/reservations/page.tsx` ([src/app/[locale]/admin/reservations/page.tsxR2](diffhunk://#diff-71c46347ac4b2caada72167cc60ba0251d6b4ecbe8929b4cd9069eb836b346c6R2))
  - `src/app/[locale]/admin/reservations/ticket/[id]/page.tsx` ([src/app/[locale]/admin/reservations/ticket/[id]/page.tsxR2](diffhunk://#diff-b87b2d1f2e915db0e37e4764aad6468c1dafa157669764f66de1bc68e8eab50aR2))
  - `src/app/[locale]/admin/users/[userId]/page.tsx` ([src/app/[locale]/admin/users/[userId]/page.tsxR2](diffhunk://#diff-ed623dcaa7c37fc3a60a66d0f15fe7d8145858fad5e31042c96fd4a5b2cc90d2R2))
  - `src/app/[locale]/admin/users/page.tsx` ([src/app/[locale]/admin/users/page.tsxR2](diffhunk://#diff-23549e62e9cdf9a004c180a81499896f5edb7e9a6c0cd515b25b78565073df04R2))
  - `src/app/[locale]/list/lodge/page.tsx` ([src/app/[locale]/list/lodge/page.tsxR2](diffhunk://#diff-670afcb0a7571cee14cee3f24bb391ca5deaf3e3671f053f477dac28b30d9398R2))
  - `src/app/[locale]/lodge/[lodgeId]/page.tsx` ([src/app/[locale]/lodge/[lodgeId]/page.tsxR2](diffhunk://#diff-b5bc77e1fd0a1af9d3b95de179d38f70eaecbff6a4fcbe38d97ef40c19d96558R2))
  - `src/app/[locale]/login/page.tsx` ([src/app/[locale]/login/page.tsxR2](diffhunk://#diff-869eb45de992a1ca037683886a3b436c82b5545b9459c4c4a6c2c6e510dd3029R2))
  - `src/app/[locale]/profile/page.tsx` ([src/app/[locale]/profile/page.tsxR2](diffhunk://#diff-e1e0960becceaa9b4d84f276ba851f5b57e01a87ac7c6f90a7d27ada98957d1cR2))
  - `src/app/[locale]/profile/reservations/page.tsx` ([src/app/[locale]/profile/reservations/page.tsxR2](diffhunk://#diff-5cd982559bb344195992b8c9bc4c9195d026e44a53a830cffe15481bf58774b6R2))
  - `src/app/[locale]/profile/reviews/page.tsx` ([src/app/[locale]/profile/reviews/page.tsxR2](diffhunk://#diff-9c00336931ef78b4c543fe79fb9dbff42aa64b13ea10761bac54df38802ba68aR2))
  - `src/app/[locale]/reservation/confirm/page.tsx` ([src/app/[locale]/reservation/confirm/page.tsxR2](diffhunk://#diff-29ae2b88a0074f01e8c64ec4fd436d3372d2340e1cc22569710b57cd3738c3a6R2))
  - `src/app/[locale]/reservation/fail/page.tsx` ([src/app/[locale]/reservation/fail/page.tsxR2](diffhunk://#diff-55cf3e8ea9cce5d5b79483d5faf5e5d94202c5fc654c24d5a15b906fcb3b8b30R2))
  - `src/app/[locale]/reservation/page.tsx` ([src/app/[locale]/reservation/page.tsxR2](diffhunk://#diff-a0a0499d46d20e68a7e69ca293c8eee6ae8f2400aa7de1d22ee4b79a38580558R2))
  - `src/app/[locale]/reservation/success/page.tsx` ([src/app/[locale]/reservation/success/page.tsxR2](diffhunk://#diff-2646a3735f80a13e5d599fc4e3b851a7d88bcb935507a97eb392ebf1f860e2bdR2))
  - `src/app/[locale]/reset-password/page.tsx` ([src/app/[locale]/reset-password/page.tsxR2](diffhunk://#diff-fa8799b7db6f71e907fdfb8604cf093baf1a04a1207958dbd6715fa7b8c79c59R2))

### Minor Correction:

* Fixed a formatting inconsistency in `src/app/[locale]/admin/lodge/[lodgeId]/page.tsx` by changing `export const runtime = 'edge';` to use double quotes instead of single quotes for consistency with the rest of the codebase. ([src/app/[locale]/admin/lodge/[lodgeId]/page.tsxL1-R2](diffhunk://#diff-388e0cf1c158ecbf1212c98ce312e280ba67bd753da2fc137c7e8d213950c091L1-R2))

## Linked Issues  
<!-- 
Reference any related issues/tickets with keywords like `Closes #1`, `Fixes #2`, etc.  
If none, write "None"
-->

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [ ] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [ ] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
