### PR TITLE
Feat/translation

### DIFF
--- a/src/components/reviews/LodgeReviewCreateModal.tsx
+++ b/src/components/reviews/LodgeReviewCreateModal.tsx
@@ -11,13 +11,14 @@ import "@smastrom/react-rating/style.css";
 import { Review } from "@/types/reivew";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
+import { getLocalizedReviewLodge } from "@/utils/getLocalizedReviewLodge";
 
 interface Props {
   onClose: () => void;
 }
 
 const LodgeReviewCreateModal: React.FC<Props> = ({ onClose }) => {
-  const { t } = useTranslation("lodge-review-create");
+  const { t, i18n } = useTranslation("lodge-review-create");
   const [reservationId, setReservationId] = useState<number | null>(null);
 
   const [createReview] = useCreateReviewMutation();
@@ -90,7 +91,8 @@ const LodgeReviewCreateModal: React.FC<Props> = ({ onClose }) => {
             <option value="">{t("selectPlaceholder")}</option>
             {eligibleLodges?.map((r) => (
               <option key={r.id} value={r.id}>
-                {r.lodge.name} ({formatDate(r.checkIn)} ~ {formatDate(r.checkOut)})
+                {getLocalizedReviewLodge(r.lodge, i18n.language)} (
+                {formatDate(r.checkIn)} ~ {formatDate(r.checkOut)})
               </option>
             ))}
           </select>
@@ -100,7 +102,11 @@ const LodgeReviewCreateModal: React.FC<Props> = ({ onClose }) => {
           <label className="block text-sm font-medium text-gray-700">
             {t("ratingLabel")}
           </label>
-          <Rating value={rating} onChange={setRating} style={{ maxWidth: 180 }} />
+          <Rating
+            value={rating}
+            onChange={setRating}
+            style={{ maxWidth: 180 }}
+          />
         </div>
 
         <div className="space-y-2">

--- a/src/utils/getLocalizedReviewLodge.ts
+++ b/src/utils/getLocalizedReviewLodge.ts
@@ -1,0 +1,13 @@
+import { getLocalizedField } from "./getLocalizedField";
+
+interface ReviewLodge {
+  name: string | null | undefined;
+  nameEn?: string | null | undefined;
+}
+
+export function getLocalizedReviewLodge(
+  lodge: ReviewLodge,
+  locale: string
+): string {
+  return getLocalizedField(lodge.name, lodge.nameEn, locale);
+}


### PR DESCRIPTION
# Pull Request

This pull request enhances the lodge review creation modal by improving the localization of lodge names and refactoring related logic. The most important changes include introducing a utility function for localized lodge names and updating the modal to use it.

**Localization improvements:**

* Added a new utility function `getLocalizedReviewLodge` in `src/utils/getLocalizedReviewLodge.ts` to return the lodge name based on the current locale, leveraging the existing `getLocalizedField` helper.
* Updated `LodgeReviewCreateModal` in `src/components/reviews/LodgeReviewCreateModal.tsx` to use `getLocalizedReviewLodge` when displaying lodge names in the dropdown, ensuring users see names in their preferred language. [[1]](diffhunk://#diff-69538f87c65f5b6a51b6a7d94e3c7cebcdc6d93a43b8043918861ea7d3fb8b8fR14-R21) [[2]](diffhunk://#diff-69538f87c65f5b6a51b6a7d94e3c7cebcdc6d93a43b8043918861ea7d3fb8b8fL93-R95)

**Minor code improvements:**

* Passed the `i18n` object from `useTranslation` to access the current language for localization.
* Minor formatting update to the `Rating` component for better readability, with no change to functionality.

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [x] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
