### PR TITLE
Feat/translation

### DIFF
--- a/public/locales/en/ticket-reservation-card.json
+++ b/public/locales/en/ticket-reservation-card.json
@@ -11,5 +11,6 @@
     "pending": "Pending",
     "cancelled": "Cancelled",
     "none": "No Status"
-  }
+  },
+  "totalPrice": "Total Price: {{price}} KRW"
 }

--- a/public/locales/ko/ticket-reservation-card.json
+++ b/public/locales/ko/ticket-reservation-card.json
@@ -9,5 +9,6 @@
     "pending": "진행중",
     "cancelled": "예약취소",
     "none": "상태 없음"
-  }
+  },
+  "totalPrice": "총 가격: {{price}}원"
 }

--- a/src/components/reservations/TicketReservationCard.tsx
+++ b/src/components/reservations/TicketReservationCard.tsx
@@ -61,7 +61,7 @@ const TicketReservationCard: React.FC<TicketReservationCardProps> = ({
       </div>
       <div className="space-y-2">
         <p className="text-sm text-gray-700">
-          {t("date", { date: formatKSTDate(ticket.date) })}
+          {t("date")} : {formatKSTDate(ticket.date)}
         </p>
         <p className="text-sm text-gray-700">
           {t("adultsWithCount", { count: ticket.adults })},{" "}
@@ -71,7 +71,7 @@ const TicketReservationCard: React.FC<TicketReservationCardProps> = ({
           {t("totalPrice", {
             price: ticket.totalPrice?.toLocaleString() || "계산 안됨",
           })}
-          원
+          
         </p>
         <p className="text-sm text-gray-500">
           {t("createdAt", {


### PR DESCRIPTION
# Pull Request

This pull request updates the ticket reservation card to improve localization and display formatting for the reservation date and total price. The main changes include adding new translation keys for total price in both English and Korean, updating how the reservation date is rendered, and refining the display of the total price.

**Localization improvements:**

* Added a new translation key `totalPrice` to both `public/locales/en/ticket-reservation-card.json` and `public/locales/ko/ticket-reservation-card.json` to support localized display of the total price. [[1]](diffhunk://#diff-332759f85966c08ab0d649364d64b85c0f2ab6d54a1f39d62e070ae6cbfd3bebL14-R15) [[2]](diffhunk://#diff-c06599522c9022b3cc4c618d811af937d1b8a1dd3d20edb9ec46903ca5965c0fL12-R13)

**UI display updates:**

* Changed the reservation date display in `TicketReservationCard.tsx` to show the label and formatted date separately, improving readability and consistency with other fields.
* Updated the total price display in `TicketReservationCard.tsx` to use the new localized string, removing the hardcoded currency symbol and ensuring proper formatting.

## Linked Issues  
Fixes #198 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
