### PR TITLE
Feat/translation

### DIFF
--- a/src/components/reviews/TicketReview.tsx
+++ b/src/components/reviews/TicketReview.tsx
@@ -16,6 +16,8 @@ import TicketReviewCreateModal from "./TicketReviewCreateModal";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
 import { showConfirm } from "@/utils/showConfirm";
+import { getLocalizedField } from "@/utils/getLocalizedField";
+import { useLocale } from "@/utils/useLocale";
 
 const TicketReview = () => {
   const { t } = useTranslation("ticket-review");
@@ -39,6 +41,8 @@ const TicketReview = () => {
   const reviews = data?.data || [];
   const totalCount = data?.total || 0;
   const totalPages = Math.ceil(totalCount / pageSize);
+
+  const locale = useLocale();
 
   const toggleMenu = (id: string) => {
     setOpenMenuId((prevId) => (prevId === id ? null : id));
@@ -139,12 +143,19 @@ const TicketReview = () => {
                 {review.reservation && (
                   <p className="text-md text-primary-900">
                     <span className="text-lg font-semibold mr-3">
-                      {review.reservation?.ticketType?.name || t("unknown")}
+                      {getLocalizedField(
+                        review.reservation?.ticketType?.name,
+                        review.reservation?.ticketType?.nameEn,
+                        locale
+                      ) || t("unknown")}{" "}
                     </span>
                     <span className="text-gray-600 ml-1 text-sm">
                       -{" "}
-                      {review.reservation?.ticketType?.lodge?.name ||
-                        t("noLodge")}
+                      {getLocalizedField(
+                        review.reservation?.ticketType?.lodge?.name,
+                        review.reservation?.ticketType?.lodge?.nameEn,
+                        locale
+                      ) || t("noLodge")}
                     </span>
                     ({review.reservation?.date?.slice(0, 10) || t("unknown")})
                   </p>
@@ -198,7 +209,9 @@ const TicketReview = () => {
                   className="w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all duration-200 text-gray-700 placeholder-gray-400"
                 />
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-gray-600">{t("editRatingLabel")}</span>
+                  <span className="text-sm text-gray-600">
+                    {t("editRatingLabel")}
+                  </span>
                   <Rating
                     value={editingRating ?? 0}
                     onChange={setEditingRating}

--- a/src/components/reviews/TicketReviewCreateModal.tsx
+++ b/src/components/reviews/TicketReviewCreateModal.tsx
@@ -69,8 +69,6 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
     return isBeforeOrToday && isNotReviewed;
   });
 
-  console.log("✅ eligibleTickets", eligibleTickets);
-
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     return `${date.getFullYear()}년 ${

--- a/src/components/reviews/TicketReviewCreateModal.tsx
+++ b/src/components/reviews/TicketReviewCreateModal.tsx
@@ -69,6 +69,8 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
     return isBeforeOrToday && isNotReviewed;
   });
 
+  console.log("✅ eligibleTickets", eligibleTickets);
+
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     return `${date.getFullYear()}년 ${
@@ -121,7 +123,12 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
             <option value="">{t("selectPlaceholder")}</option>
             {eligibleTickets?.map((t) => (
               <option key={t.id} value={t.id}>
-                {getLocalizedField(t.ticketType.name, t.ticketType.nameEn, locale)} - {formatDate(t.date)}
+                {getLocalizedField(
+                  t.ticketType.name,
+                  t.ticketType.nameEn,
+                  locale
+                )}{" "}
+                - {formatDate(t.date)}
               </option>
             ))}
           </select>
@@ -131,7 +138,11 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
           <label className="block text-sm font-medium text-gray-700">
             {t("ratingLabel")}
           </label>
-          <Rating value={rating} onChange={setRating} style={{ maxWidth: 180 }} />
+          <Rating
+            value={rating}
+            onChange={setRating}
+            style={{ maxWidth: 180 }}
+          />
         </div>
 
         <div className="space-y-2">

--- a/src/components/reviews/TicketReviewCreateModal.tsx
+++ b/src/components/reviews/TicketReviewCreateModal.tsx
@@ -11,6 +11,8 @@ import "@smastrom/react-rating/style.css";
 import { fetchTicketReservations } from "@/lib/ticket-reservation/ticketReservationThunk";
 import { useTranslation } from "react-i18next";
 import toast from "react-hot-toast";
+import { useLocale } from "@/utils/useLocale";
+import { getLocalizedField } from "@/utils/getLocalizedField";
 
 interface Props {
   onClose: () => void;
@@ -23,6 +25,7 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
   );
 
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const [createReview] = useCreateTicketReviewMutation();
   const tickets = useAppSelector((state) => state.ticketReservation.list);
@@ -118,7 +121,7 @@ const TicketReviewCreateModal: React.FC<Props> = ({ onClose }) => {
             <option value="">{t("selectPlaceholder")}</option>
             {eligibleTickets?.map((t) => (
               <option key={t.id} value={t.id}>
-                {t.ticketType.name} - {formatDate(t.date)}
+                {getLocalizedField(t.ticketType.name, t.ticketType.nameEn, locale)} - {formatDate(t.date)}
               </option>
             ))}
           </select>


### PR DESCRIPTION
# Pull Request

This pull request enhances localization support for ticket reviews by introducing dynamic language selection for ticket type and lodge names. It refactors the code to use the current locale, ensuring that users see information in their preferred language, and improves code readability in several places.

**Localization improvements:**

* Integrated the `getLocalizedField` utility and `useLocale` hook to dynamically select ticket type and lodge names based on the user's locale in both `TicketReview.tsx` and `TicketReviewCreateModal.tsx`. [[1]](diffhunk://#diff-3971e03261a473d23bd3b1318fbcc77f90df7afbf4c63e02bd98509ded45f0d5R19-R20) [[2]](diffhunk://#diff-c6f6451ca7f78b73ca2fc2072a00a937f75ea6fbc41d0f13b419eec9e110969fR14-R15) [[3]](diffhunk://#diff-3971e03261a473d23bd3b1318fbcc77f90df7afbf4c63e02bd98509ded45f0d5R45-R46) [[4]](diffhunk://#diff-c6f6451ca7f78b73ca2fc2072a00a937f75ea6fbc41d0f13b419eec9e110969fR28)
* Updated ticket type and lodge name rendering in the ticket review list and the create modal to use localized fields, falling back to English or default values when necessary. [[1]](diffhunk://#diff-3971e03261a473d23bd3b1318fbcc77f90df7afbf4c63e02bd98509ded45f0d5L142-R158) [[2]](diffhunk://#diff-c6f6451ca7f78b73ca2fc2072a00a937f75ea6fbc41d0f13b419eec9e110969fL121-R129)

**Code readability and UI improvements:**

* Refactored JSX in both components for better readability, including formatting and splitting props across multiple lines for the `Rating` component. [[1]](diffhunk://#diff-3971e03261a473d23bd3b1318fbcc77f90df7afbf4c63e02bd98509ded45f0d5L201-R214) [[2]](diffhunk://#diff-c6f6451ca7f78b73ca2fc2072a00a937f75ea6fbc41d0f13b419eec9e110969fL131-R143)

## Linked Issues  
Fixes #200 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
