### PR TITLE
Fix/frontend

### DIFF
--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -171,7 +171,7 @@ const HeaderBar = () => {
 
                     <button
                       onClick={goProfile}
-                      className="md:hidden w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
+                      className="w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
                     >
                       {t("profileButton")}
                     </button>
@@ -194,7 +194,7 @@ const HeaderBar = () => {
 
                     <button
                       onClick={goProfile}
-                      className="md:hidden w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
+                      className="w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
                     >
                       {t("profileButton")}
                     </button>

--- a/src/components/ui/ImageModal.tsx
+++ b/src/components/ui/ImageModal.tsx
@@ -3,6 +3,7 @@
 import { ArrowLeft, ArrowRight, X } from "lucide-react";
 import Image from "next/image";
 import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 interface ImageModalProps {
   isOpen: boolean;
@@ -25,6 +26,11 @@ export default function ImageModal({
 }: ImageModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [touchStartX, setTouchStartX] = useState<number | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -45,7 +51,7 @@ export default function ImageModal({
     };
   }, [isOpen, onClose, onPrev, onNext]);
 
-  if (!isOpen || images.length === 0) return null;
+  if (!isOpen || images.length === 0 || !mounted) return null;
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) onClose();
@@ -65,103 +71,107 @@ export default function ImageModal({
   const total = images.length;
   const idx = Math.min(Math.max(currentIndex, 0), total - 1);
 
-  return (
+  const modalUI = (
     <div
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/90 px-3 sm:px-4"
+      className="fixed inset-0 z-50 bg-black/90 overflow-y-auto overscroll-contain"
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
       aria-label="Image preview"
     >
-      <div className="relative w-full max-w-5xl flex items-center justify-between text-white mb-2 sm:mb-3">
-        <span className="text-xs sm:text-sm opacity-80">
-          {idx + 1} / {total}
-        </span>
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          className="p-2 rounded-md hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white"
-        >
-          <X className="w-6 h-6 sm:w-7 sm:h-7" />
-        </button>
-      </div>
-
-      <div
-        ref={containerRef}
-        className="relative w-full max-w-5xl h-[60vh] sm:h-[70vh] md:h-[80vh] flex items-center justify-center select-none"
-        onClick={(e) => e.stopPropagation()}
-        onTouchStart={onTouchStart}
-        onTouchEnd={onTouchEnd}
-      >
-        <button
-          onClick={onPrev}
-          aria-label="Previous image"
-          className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2
-                     inline-flex items-center justify-center
-                     w-10 h-10 sm:w-12 sm:h-12 rounded-full
-                     bg-white/10 hover:bg-white/20 text-white
-                     focus:outline-none focus:ring-2 focus:ring-white z-10"
-        >
-          <ArrowLeft className="w-5 h-5 sm:w-6 sm:h-6" />
-        </button>
-
-        <div className="absolute inset-0">
-          <Image
-            src={images[idx]}
-            alt={`image-${idx + 1}`}
-            fill
-            sizes="(max-width: 640px) 100vw, 90vw"
-            className="object-contain rounded-md"
-            priority
-          />
+      <div className="min-h-[100dvh] flex flex-col items-center justify-center px-3 sm:px-4">
+        <div className="relative w-full max-w-5xl flex items-center justify-between text-white mb-2 sm:mb-3">
+          <span className="text-xs sm:text-sm opacity-80">
+            {idx + 1} / {total}
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-2 rounded-md hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white"
+          >
+            <X className="w-6 h-6 sm:w-7 sm:h-7" />
+          </button>
         </div>
 
-        <button
-          onClick={onNext}
-          aria-label="Next image"
-          className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2
-                     inline-flex items-center justify-center
-                     w-10 h-10 sm:w-12 sm:h-12 rounded-full
-                     bg-white/10 hover:bg-white/20 text-white
-                     focus:outline-none focus:ring-2 focus:ring-white z-10"
+        <div
+          ref={containerRef}
+          className="relative w-full max-w-5xl h-[65vh] sm:h-[75vh] md:h-[80vh] flex items-center justify-center select-none"
+          onClick={(e) => e.stopPropagation()}
+          onTouchStart={onTouchStart}
+          onTouchEnd={onTouchEnd}
         >
-          <ArrowRight className="w-5 h-5 sm:w-6 sm:h-6" />
-        </button>
-      </div>
+          <button
+            onClick={onPrev}
+            aria-label="Previous image"
+            className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2
+                       inline-flex items-center justify-center
+                       w-10 h-10 sm:w-12 sm:h-12 rounded-full
+                       bg-white/10 hover:bg-white/20 text-white
+                       focus:outline-none focus:ring-2 focus:ring-white z-10"
+          >
+            <ArrowLeft className="w-5 h-5 sm:w-6 sm:h-6" />
+          </button>
 
-      <div
-        className="mt-4 sm:mt-6 w-full max-w-5xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex gap-2 sm:gap-3 overflow-x-auto px-1 sm:px-2 snap-x snap-mandatory">
-          {images.map((url, i) => {
-            const active = i === idx;
-            return (
-              <button
-                key={i}
-                onClick={() => setCurrentIndex(i)}
-                aria-label={`Go to image ${i + 1}`}
-                className={`relative shrink-0 snap-start rounded-md overflow-hidden
-                            ${
-                              active
-                                ? "ring-2 ring-offset-2 ring-blue-400 ring-offset-black/0"
-                                : ""
-                            }
-                            focus:outline-none focus:ring-2 focus:ring-blue-400`}
-                style={{ width: "5.5rem", height: "3.5rem" }} // ~ 88x56
-              >
-                <Image
-                  src={url}
-                  alt={`thumbnail-${i + 1}`}
-                  fill
-                  sizes="88px"
-                  className="object-cover"
-                />
-              </button>
-            );
-          })}
+          <div className="absolute inset-0">
+            <Image
+              src={images[idx]}
+              alt={`image-${idx + 1}`}
+              fill
+              sizes="(max-width: 640px) 100vw, 90vw"
+              className="object-contain rounded-md"
+              priority
+            />
+          </div>
+
+          <button
+            onClick={onNext}
+            aria-label="Next image"
+            className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2
+                       inline-flex items-center justify-center
+                       w-10 h-10 sm:w-12 sm:h-12 rounded-full
+                       bg-white/10 hover:bg-white/20 text-white
+                       focus:outline-none focus:ring-2 focus:ring-white z-10"
+          >
+            <ArrowRight className="w-5 h-5 sm:w-6 sm:h-6" />
+          </button>
+        </div>
+
+        <div
+          className="mt-4 sm:mt-6 w-full max-w-5xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex gap-2 sm:gap-3 overflow-x-auto px-1 sm:px-2 snap-x snap-mandatory">
+            {images.map((url, i) => {
+              const active = i === idx;
+              return (
+                <button
+                  key={i}
+                  onClick={() => setCurrentIndex(i)}
+                  aria-label={`Go to image ${i + 1}`}
+                  className={`relative shrink-0 snap-start rounded-md overflow-hidden
+                              ${
+                                active
+                                  ? "ring-2 ring-offset-2 ring-blue-400 ring-offset-black/0"
+                                  : ""
+                              }
+                              focus:outline-none focus:ring-2 focus:ring-blue-400`}
+                  style={{ width: "5.5rem", height: "3.5rem" }}
+                >
+                  <Image
+                    src={url}
+                    alt={`thumbnail-${i + 1}`}
+                    fill
+                    sizes="88px"
+                    className="object-cover"
+                  />
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>
   );
+
+  return createPortal(modalUI, document.body);
 }


### PR DESCRIPTION
# Pull Request

## Description  
- Updated TicketDetail page’s ImageModal to match the design and behavior of the LodgeDetail page modal (scrollable content, correct centering, improved touch/swipe support)
- Fixed HeaderBar "Go to Profile" button so it always appears in the dropdown menu on all screen sizes (removed md:hidden)

## Why  
- The TicketDetail ImageModal had inconsistent UI and UX compared to LodgeDetail, leading to different behaviors and styling between pages.
- The HeaderBar "Go to Profile" button was hidden on desktop due to responsive classes, preventing easy navigation for desktop users.

## Testing  
- Ran the app locally
- Opened TicketDetail page, clicked on the main image, and confirmed the modal matches LodgeDetail styling and interaction
- Tested image navigation via buttons, keyboard arrows, and swipe gestures
- Checked HeaderBar dropdown on desktop, tablet, and mobile — confirmed the "Go to Profile" button is always visible
- Verified no regressions on LodgeDetail page ImageModal

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
