### PR TITLE
Feat/side menu bar

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -3,5 +3,6 @@
   "loginButton": "Login",
   "logoutButton": "Logout",
   "adminButton": "Go to Admin",
-  "profileButton": "Go to Profile"
+  "profileButton": "Go to Profile",
+  "greetingInline": "Hello, {{nickname}}"
 }

--- a/public/locales/ko/header.json
+++ b/public/locales/ko/header.json
@@ -3,5 +3,6 @@
   "loginButton": "로그인",
   "logoutButton": "로그아웃",
   "adminButton": "관리자 페이지로 이동",
-  "profileButton": "프로필로 이동"
+  "profileButton": "프로필로 이동",
+  "greetingInline": "{{nickname}}님 안녕하세요"
 }

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,23 +1,19 @@
 import Image from "next/image";
 import { useRouter, usePathname } from "next/navigation";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "../lib/store/hooks";
 import { logoutUser } from "../lib/auth/logoutThunk";
 import i18n from "i18next";
 import { useLocale } from "@/utils/useLocale";
-import { useTranslation } from "react-i18next";
+import SideMenu from "./SideMenu";
+import { Menu } from "lucide-react";
 
 const HeaderBar = () => {
-  const { t } = useTranslation("header");
   const [select, setSelect] = useState(i18n.language || "ko");
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
 
   const [isDesktop, setIsDesktop] = useState(false);
-
-  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const pathname = usePathname();
   const router = useRouter();
@@ -30,28 +26,6 @@ const HeaderBar = () => {
     { name: "English", code: "en" },
     { name: "한국어", code: "ko" },
   ];
-
-  const clearTimers = () => {
-    if (openTimer.current) clearTimeout(openTimer.current);
-    if (closeTimer.current) clearTimeout(closeTimer.current);
-  };
-
-  const scheduleOpen = () => {
-    clearTimers();
-    openTimer.current = setTimeout(() => setMenuOpen(true), 80);
-  };
-
-  const scheduleClose = () => {
-    clearTimers();
-    closeTimer.current = setTimeout(() => setMenuOpen(false), 200);
-  };
-
-  useEffect(() => {
-    return () => clearTimers();
-  }, []);
-
-  const onProfileEnter = () => isDesktop && scheduleOpen();
-  const onProfileLeave = () => isDesktop && scheduleClose();
 
   useEffect(() => {
     const updateLanguage = () => {
@@ -96,10 +70,6 @@ const HeaderBar = () => {
     router.push(`/${locale}/`);
   };
 
-  const goProfile = () => {
-    router.push(user ? `/${locale}/profile` : `/${locale}/login`);
-  };
-
   return (
     <header className="sticky top-0 z-40 w-full border-b border-primary-800 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/70">
       <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-3 sm:px-4 md:h-16">
@@ -140,142 +110,25 @@ const HeaderBar = () => {
             ))}
           </select>
 
-          <div
-            ref={menuRef}
-            className="relative"
-            onMouseEnter={onProfileEnter}
-            onMouseLeave={onProfileLeave}
+          <button
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            aria-haspopup="dialog"
+            aria-expanded={menuOpen}
+            className="relative h-10 w-10 inline-flex items-center justify-center"
           >
-            <button
-              onMouseEnter={onProfileEnter}
-              onMouseLeave={onProfileLeave}
-              onClick={() => setMenuOpen((v) => !v)}
-              className="relative flex h-10 w-10 items-center justify-center rounded-full"
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-              aria-label="Account menu"
-            >
-              <span
-                className={`absolute inset-0 rounded-full transition-opacity ${
-                  menuOpen ? "opacity-100" : "opacity-0"
-                }`}
-                style={{
-                  background:
-                    "radial-gradient(circle, rgba(59,130,246,0.25) 20%, rgba(59,130,246,0.06) 70%, transparent 100%)",
-                  boxShadow: "0 0 10px rgba(59,130,246,0.18)",
-                }}
-                aria-hidden="true"
-              />
-              <i className="bi bi-person-circle text-primary-800 text-2xl md:text-3xl relative z-10" />
-            </button>
-
-            {menuOpen && (
-              <div
-                onMouseEnter={onProfileEnter}
-                onMouseLeave={onProfileLeave}
-                className="absolute right-0 top-10 w-64 h-3"
-                style={{ background: "transparent" }}
-              />
-            )}
-
-            {/* Dropdown */}
-            {menuOpen && (
-              <div
-                role="menu"
-                onMouseEnter={onProfileEnter}
-                onMouseLeave={onProfileLeave}
-                className="absolute right-0 top-12 w-64 bg-white border border-gray-200 rounded-xl shadow-lg p-4 space-y-3 z-50 animate-dropdown"
-              >
-                {!user ? (
-                  <div className="space-y-3">
-                    <p className="text-gray-900 text-sm font-medium">
-                      {t("loginPrompt")}
-                    </p>
-                    <button
-                      onClick={() => router.push(`/${locale}/login`)}
-                      className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
-                    >
-                      {t("loginButton")}
-                    </button>
-                  </div>
-                ) : user.role !== "ADMIN" ? (
-                  <div className="space-y-3">
-                    <div className="min-w-0">
-                      <p className="text-gray-900 text-sm font-semibold truncate">
-                        {user.nickname}
-                      </p>
-                      <p className="text-gray-600 text-xs truncate">
-                        {user.email}
-                      </p>
-                    </div>
-
-                    <button
-                      onClick={goProfile}
-                      className="w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
-                    >
-                      {t("profileButton")}
-                    </button>
-
-                    <button
-                      onClick={handleLogout}
-                      className="w-full bg-red-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition"
-                    >
-                      {t("logoutButton")}
-                    </button>
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="min-w-0">
-                      <p className="text-gray-900 text-sm font-semibold truncate">
-                        {user.nickname}
-                      </p>
-                      <p className="text-gray-600 text-xs truncate">
-                        {user.email}
-                      </p>
-                    </div>
-
-                    <button
-                      onClick={goProfile}
-                      className="w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
-                    >
-                      {t("profileButton")}
-                    </button>
-
-                    <button
-                      onClick={handleLogout}
-                      className="w-full bg-red-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition"
-                    >
-                      {t("logoutButton")}
-                    </button>
-                    <button
-                      onClick={() => router.push(`/${locale}/admin`)}
-                      className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition"
-                    >
-                      {t("adminButton")}
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+            <Menu className="h-5 w-5 text-primary-800" aria-hidden="true" />
+          </button>
         </div>
       </div>
 
-      <style jsx>{`
-        @keyframes dropdown {
-          0% {
-            opacity: 0;
-            transform: translateY(-8px);
-          }
-          100% {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-        .animate-dropdown {
-          animation: dropdown 0.18s ease-out forwards;
-        }
-      `}</style>
+      <SideMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        user={user}
+        locale={locale}
+        onLogout={handleLogout}
+      />
     </header>
   );
 };

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { createPortal } from "react-dom";
+import { Home } from "lucide-react";
+
+type User = {
+  nickname: string;
+  role?: "ADMIN" | "USER" | string;
+  email?: string;
+} | null;
+
+type SideMenuProps = {
+  open: boolean;
+  onClose: () => void;
+  user?: User;
+  locale: string;
+  onLogout: () => Promise<void>;
+};
+
+const SideMenu: React.FC<SideMenuProps> = ({
+  open,
+  onClose,
+  user,
+  locale,
+  onLogout,
+}) => {
+  const { t } = useTranslation("header");
+  const router = useRouter();
+  const menuRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (open) {
+      document.addEventListener("keydown", handleKeydown);
+      document.addEventListener("mousedown", handleOutsideClick);
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeydown);
+      document.removeEventListener("mousedown", handleOutsideClick);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  const handleNavigation = (path: string) => {
+    onClose();
+    router.push(`/${locale}${path}`);
+  };
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <>
+      <div
+        className={`fixed inset-0 z-[998] bg-black/50 transition-opacity duration-300 ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <aside
+        ref={menuRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Side menu"
+        className={`fixed top-0 right-0 z-[999] h-[100dvh] w-80 max-w-[88%] 
+          bg-white/95 backdrop-saturate-150 shadow-2xl border-l border-gray-200 
+          flex flex-col 
+          transition-transform duration-300 ease-in-out 
+          ${open ? "translate-x-0" : "translate-x-full"}
+          pt-[max(12px,env(safe-area-inset-top))]
+          pr-[max(12px,env(safe-area-inset-right))]
+          pb-[max(12px,env(safe-area-inset-bottom))]
+          pl-4
+        `}
+        style={{ WebkitOverflowScrolling: "touch" }}
+      >
+        <div className="flex items-center justify-between pb-4 border-b border-gray-200 shrink-0 pr-2">
+          <h2 className="text-base font-semibold text-gray-900">
+            {user ? t("menuTitle") : t("welcomeTitle")}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label={t("closeMenu")}
+            className="h-9 w-9 inline-flex items-center justify-center rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5 text-gray-700"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto pt-6 pr-2 space-y-6">
+          {user ? (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-800">
+                <button
+                  onClick={() => handleNavigation("/profile")}
+                  className="underline text-primary-700 font-medium"
+                  aria-label="Go to profile"
+                >
+                  {user.nickname}
+                </button>
+                <span className="ml-1">님 안녕하세요</span>
+              </p>
+
+              <button
+                onClick={() => handleNavigation("/profile")}
+                className="w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 transition"
+              >
+                {t("profilePage")}
+              </button>
+
+              {user.role === "ADMIN" && (
+                <button
+                  onClick={() => handleNavigation("/admin")}
+                  className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 transition"
+                >
+                  {t("adminPage")}
+                </button>
+              )}
+
+              <button
+                onClick={async () => {
+                  await onLogout();
+                  onClose();
+                }}
+                className="w-full bg-red-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-700 transition"
+              >
+                {t("logout")}
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4 text-center">
+              <p className="text-sm text-gray-700">{t("pleaseLogin")}</p>
+              <button
+                onClick={() => handleNavigation("/login")}
+                className="text-primary-700 underline font-medium"
+              >
+                {t("login")}
+              </button>
+            </div>
+          )}
+
+          <div className="pt-6 border-t border-gray-200">
+            <button
+              onClick={() => handleNavigation("/")}
+              className="block w-full text-left text-sm text-gray-700 hover:text-primary-700"
+            >
+              <Home className="inline-block text-primary-800 mr-2" />
+              {t("home")}
+            </button>
+          </div>
+        </div>
+      </aside>
+    </>,
+    document.body
+  );
+};
+
+export default SideMenu;

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -15,6 +15,8 @@ import {
   CalendarDays,
   MessageSquare,
   Settings as SettingsIcon,
+  HelpCircle,
+  Mail,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -45,10 +47,14 @@ const SideMenu: React.FC<SideMenuProps> = ({
   const menuRef = useRef<HTMLElement>(null);
 
   const [profileOpen, setProfileOpen] = useState(false);
+  const [supportOpen, setSupportOpen] = useState(false);
 
   useEffect(() => {
     if (pathname?.replace(`/${locale}`, "").startsWith("/profile")) {
       setProfileOpen(true);
+    }
+    if (pathname?.replace(`/${locale}`, "").startsWith("/help")) {
+      setSupportOpen(true);
     }
   }, [pathname, locale]);
 
@@ -77,6 +83,11 @@ const SideMenu: React.FC<SideMenuProps> = ({
   const handleNavigation = (path: string) => {
     onClose();
     router.push(`/${locale}${path}`);
+  };
+
+  const isActive = (path: string) => {
+    const full = `/${locale}${path}`;
+    return pathname === full || pathname.startsWith(`${full}/`);
   };
 
   if (typeof document === "undefined") return null;
@@ -141,80 +152,6 @@ const SideMenu: React.FC<SideMenuProps> = ({
                   defaultValue: "{{nickname}}님 안녕하세요",
                 })}
               </p>
-
-              <div className="rounded-xl border border-gray-200 overflow-hidden bg-[#FAFAFA]">
-                <button
-                  onClick={() => setProfileOpen((v) => !v)}
-                  aria-expanded={profileOpen}
-                  aria-controls="profile-submenu"
-                  className="w-full flex items-center justify-between px-3 py-3 hover:bg-white transition text-sm"
-                >
-                  <span className="flex items-center gap-2 text-gray-800">
-                    <User className="h-5 w-5 text-primary-800" />
-                    {t("profile", { defaultValue: "Profile" })}
-                  </span>
-                  {profileOpen ? (
-                    <ChevronDown className="h-5 w-5 text-gray-500 transition-transform" />
-                  ) : (
-                    <ChevronRight className="h-5 w-5 text-gray-500 transition-transform" />
-                  )}
-                </button>
-
-                <div
-                  id="profile-submenu"
-                  className="grid grid-cols-1"
-                  style={{
-                    overflow: "hidden",
-                    transition: "max-height 220ms ease",
-                    maxHeight: profileOpen ? 320 : 0,
-                  }}
-                >
-                  <button
-                    onClick={() => handleNavigation("/profile/account")}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
-                  >
-                    <UserCog className="h-4 w-4 text-primary-700" />
-                    {t("account", { defaultValue: "Account" })}
-                  </button>
-                  <button
-                    onClick={() => handleNavigation("/profile/favorites")}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
-                  >
-                    <Heart className="h-4 w-4 text-primary-700" />
-                    {t("favorites", { defaultValue: "Favorites" })}
-                  </button>
-                  <button
-                    onClick={() => handleNavigation("/profile/reservations")}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
-                  >
-                    <CalendarDays className="h-4 w-4 text-primary-700" />
-                    {t("reservations", { defaultValue: "Reservations" })}
-                  </button>
-                  <button
-                    onClick={() => handleNavigation("/profile/reviews")}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
-                  >
-                    <MessageSquare className="h-4 w-4 text-primary-700" />
-                    {t("reviews", { defaultValue: "Reviews" })}
-                  </button>
-                  <button
-                    onClick={() => handleNavigation("/profile/settings")}
-                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
-                  >
-                    <SettingsIcon className="h-4 w-4 text-primary-700" />
-                    {t("settings", { defaultValue: "Settings" })}
-                  </button>
-                </div>
-              </div>
-
-              {user.role === "ADMIN" && (
-                <button
-                  onClick={() => handleNavigation("/admin")}
-                  className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 transition"
-                >
-                  {t("adminPage")}
-                </button>
-              )}
             </div>
           ) : (
             <div className="text-left">
@@ -253,6 +190,138 @@ const SideMenu: React.FC<SideMenuProps> = ({
             >
               <Home className="h-5 w-5 text-primary-800" />
               {t("home")}
+            </button>
+          </div>
+        </div>
+
+        {user && (
+          <>
+            <div className="rounded-xl border border-gray-200 overflow-hidden bg-[#FAFAFA]">
+              <button
+                onClick={() => setProfileOpen((v) => !v)}
+                aria-expanded={profileOpen}
+                aria-controls="profile-submenu"
+                className="w-full flex items-center justify-between px-3 py-3 hover:bg-white transition text-sm"
+              >
+                <span className="flex items-center gap-2 text-gray-800">
+                  <User className="h-5 w-5 text-primary-800" />
+                  {t("profile", { defaultValue: "Profile" })}
+                </span>
+                {profileOpen ? (
+                  <ChevronDown className="h-5 w-5 text-gray-500 transition-transform" />
+                ) : (
+                  <ChevronRight className="h-5 w-5 text-gray-500 transition-transform" />
+                )}
+              </button>
+
+              <div
+                id="profile-submenu"
+                className="grid grid-cols-1"
+                style={{
+                  overflow: "hidden",
+                  transition: "max-height 220ms ease",
+                  maxHeight: profileOpen ? 320 : 0,
+                }}
+              >
+                <button
+                  onClick={() => handleNavigation("/profile/account")}
+                  className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                >
+                  <UserCog className="h-4 w-4 text-primary-700" />
+                  {t("account", { defaultValue: "Account" })}
+                </button>
+                <button
+                  onClick={() => handleNavigation("/profile/favorites")}
+                  className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                >
+                  <Heart className="h-4 w-4 text-primary-700" />
+                  {t("favorites", { defaultValue: "Favorites" })}
+                </button>
+                <button
+                  onClick={() => handleNavigation("/profile/reservations")}
+                  className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                >
+                  <CalendarDays className="h-4 w-4 text-primary-700" />
+                  {t("reservations", { defaultValue: "Reservations" })}
+                </button>
+                <button
+                  onClick={() => handleNavigation("/profile/reviews")}
+                  className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                >
+                  <MessageSquare className="h-4 w-4 text-primary-700" />
+                  {t("reviews", { defaultValue: "Reviews" })}
+                </button>
+                <button
+                  onClick={() => handleNavigation("/profile/settings")}
+                  className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                >
+                  <SettingsIcon className="h-4 w-4 text-primary-700" />
+                  {t("settings", { defaultValue: "Settings" })}
+                </button>
+              </div>
+            </div>
+
+            {user.role === "ADMIN" && (
+              <button
+                onClick={() => handleNavigation("/admin")}
+                className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 transition"
+              >
+                {t("adminPage")}
+              </button>
+            )}
+          </>
+        )}
+
+        <div className="rounded-xl border border-gray-200 overflow-hidden bg-[#FAFAFA]">
+          <button
+            onClick={() => setSupportOpen((v) => !v)}
+            aria-expanded={supportOpen}
+            aria-controls="support-submenu"
+            className="w-full flex items-center justify-between px-3 py-3 hover:bg-white transition text-sm"
+          >
+            <span className="flex items-center gap-2 text-gray-800">
+              <HelpCircle className="h-5 w-5 text-primary-800" />
+              {t("support", { defaultValue: "Support" })}
+            </span>
+            {supportOpen ? (
+              <ChevronDown className="h-5 w-5 text-gray-500 transition-transform" />
+            ) : (
+              <ChevronRight className="h-5 w-5 text-gray-500 transition-transform" />
+            )}
+          </button>
+
+          <div
+            id="support-submenu"
+            className="grid grid-cols-1"
+            style={{
+              overflow: "hidden",
+              transition: "max-height 220ms ease",
+              maxHeight: supportOpen ? 160 : 0, // 항목 2개면 충분
+            }}
+          >
+            <button
+              onClick={() => handleNavigation("/help")}
+              className={`flex items-center gap-2 px-4 py-2.5 text-sm transition text-left
+                  ${
+                    isActive("/help")
+                      ? "bg-white text-primary-800"
+                      : "text-gray-700 hover:bg-white hover:text-primary-800"
+                  }`}
+            >
+              <HelpCircle className="h-4 w-4 text-primary-700" />
+              {t("faq", { defaultValue: "FAQ" })}
+            </button>
+            <button
+              onClick={() => handleNavigation("/help/contact")}
+              className={`flex items-center gap-2 px-4 py-2.5 text-sm transition text-left
+                  ${
+                    isActive("/help/contact")
+                      ? "bg-white text-primary-800"
+                      : "text-gray-700 hover:bg-white hover:text-primary-800"
+                  }`}
+            >
+              <Mail className="h-4 w-4 text-primary-700" />
+              {t("contact", { defaultValue: "Contact" })}
             </button>
           </div>
         </div>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -17,6 +17,8 @@ import {
   Settings as SettingsIcon,
   HelpCircle,
   Mail,
+  Sun,
+  Moon,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -45,6 +47,14 @@ const SideMenu: React.FC<SideMenuProps> = ({
   const router = useRouter();
   const pathname = usePathname();
   const menuRef = useRef<HTMLElement>(null);
+
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const isDark = (theme === "system" ? resolvedTheme : theme) === "dark";
+  const toggleTheme = () => setTheme(isDark ? "light" : "dark");
 
   const [profileOpen, setProfileOpen] = useState(false);
   const [supportOpen, setSupportOpen] = useState(false);
@@ -121,26 +131,45 @@ const SideMenu: React.FC<SideMenuProps> = ({
       >
         <div className="flex items-center justify-between pb-4 border-b border-gray-200 shrink-0 pr-2">
           <h2 className="text-base font-semibold text-primary-900">Menu</h2>
-          <button
-            onClick={onClose}
-            aria-label={t("closeMenu")}
-            className="h-9 w-9 inline-flex items-center justify-center rounded-md hover:bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5 text-gray-700"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={toggleTheme}
+              aria-label={
+                isDark
+                  ? t("lightMode", { defaultValue: "Light mode" })
+                  : t("darkMode", { defaultValue: "Dark mode" })
+              }
+              className="h-9 w-9 inline-flex items-center justify-center rounded-md hover:bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
+              {mounted &&
+                (isDark ? (
+                  <Sun className="h-5 w-5 text-gray-700" />
+                ) : (
+                  <Moon className="h-5 w-5 text-gray-700" />
+                ))}
+            </button>
+
+            <button
+              onClick={onClose}
+              aria-label={t("closeMenu")}
+              className="h-9 w-9 inline-flex items-center justify-center rounded-md hover:bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 text-gray-700"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto pt-6 pr-2 space-y-6">

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,12 +1,24 @@
+// SideMenu.tsx
 "use client";
 
-import React, { useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
+import React, { useEffect, useRef, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { createPortal } from "react-dom";
-import { Home } from "lucide-react";
+import {
+  Home,
+  User,
+  ChevronDown,
+  ChevronRight,
+  UserCog,
+  Heart,
+  CalendarDays,
+  MessageSquare,
+  Settings as SettingsIcon,
+} from "lucide-react";
+import Link from "next/link";
 
-type User = {
+type UserT = {
   nickname: string;
   role?: "ADMIN" | "USER" | string;
   email?: string;
@@ -15,7 +27,7 @@ type User = {
 type SideMenuProps = {
   open: boolean;
   onClose: () => void;
-  user?: User;
+  user?: UserT;
   locale: string;
   onLogout: () => Promise<void>;
 };
@@ -29,7 +41,16 @@ const SideMenu: React.FC<SideMenuProps> = ({
 }) => {
   const { t } = useTranslation("header");
   const router = useRouter();
+  const pathname = usePathname();
   const menuRef = useRef<HTMLElement>(null);
+
+  const [profileOpen, setProfileOpen] = useState(false);
+
+  useEffect(() => {
+    if (pathname?.replace(`/${locale}`, "").startsWith("/profile")) {
+      setProfileOpen(true);
+    }
+  }, [pathname, locale]);
 
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => e.key === "Escape" && onClose();
@@ -63,7 +84,7 @@ const SideMenu: React.FC<SideMenuProps> = ({
   return createPortal(
     <>
       <div
-        className={`fixed inset-0 z-[998] bg-black/50 transition-opacity duration-300 ${
+        className={`fixed inset-0 z-[998] bg-black/40 transition-opacity duration-300 ${
           open ? "opacity-100" : "opacity-0 pointer-events-none"
         }`}
         onClick={onClose}
@@ -75,10 +96,10 @@ const SideMenu: React.FC<SideMenuProps> = ({
         role="dialog"
         aria-modal="true"
         aria-label="Side menu"
-        className={`fixed top-0 right-0 z-[999] h-[100dvh] w-80 max-w-[88%] 
-          bg-white/95 backdrop-saturate-150 shadow-2xl border-l border-gray-200 
-          flex flex-col 
-          transition-transform duration-300 ease-in-out 
+        className={`fixed top-0 right-0 z-[999] h-[100dvh] w-80 max-w-[88%]
+          bg-[#FAFAFA] shadow-2xl border-l border-gray-200
+          flex flex-col
+          transition-transform duration-300 ease-in-out
           ${open ? "translate-x-0" : "translate-x-full"}
           pt-[max(12px,env(safe-area-inset-top))]
           pr-[max(12px,env(safe-area-inset-right))]
@@ -88,13 +109,11 @@ const SideMenu: React.FC<SideMenuProps> = ({
         style={{ WebkitOverflowScrolling: "touch" }}
       >
         <div className="flex items-center justify-between pb-4 border-b border-gray-200 shrink-0 pr-2">
-          <h2 className="text-base font-semibold text-gray-900">
-            {user ? t("menuTitle") : t("welcomeTitle")}
-          </h2>
+          <h2 className="text-base font-semibold text-primary-900">Menu</h2>
           <button
             onClick={onClose}
             aria-label={t("closeMenu")}
-            className="h-9 w-9 inline-flex items-center justify-center rounded-md hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            className="h-9 w-9 inline-flex items-center justify-center rounded-md hover:bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -116,23 +135,77 @@ const SideMenu: React.FC<SideMenuProps> = ({
         <div className="flex-1 overflow-y-auto pt-6 pr-2 space-y-6">
           {user ? (
             <div className="space-y-4">
-              <p className="text-sm text-gray-800">
-                <button
-                  onClick={() => handleNavigation("/profile")}
-                  className="underline text-primary-700 font-medium"
-                  aria-label="Go to profile"
-                >
-                  {user.nickname}
-                </button>
-                <span className="ml-1">님 안녕하세요</span>
+              <p className="text-left text-sm text-gray-800 leading-6">
+                {t("greetingInline", {
+                  nickname: user.nickname,
+                  defaultValue: "{{nickname}}님 안녕하세요",
+                })}
               </p>
 
-              <button
-                onClick={() => handleNavigation("/profile")}
-                className="w-full border border-primary-600 text-primary-700 rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-50 transition"
-              >
-                {t("profilePage")}
-              </button>
+              <div className="rounded-xl border border-gray-200 overflow-hidden bg-[#FAFAFA]">
+                <button
+                  onClick={() => setProfileOpen((v) => !v)}
+                  aria-expanded={profileOpen}
+                  aria-controls="profile-submenu"
+                  className="w-full flex items-center justify-between px-3 py-3 hover:bg-white transition text-sm"
+                >
+                  <span className="flex items-center gap-2 text-gray-800">
+                    <User className="h-5 w-5 text-primary-800" />
+                    {t("profile", { defaultValue: "Profile" })}
+                  </span>
+                  {profileOpen ? (
+                    <ChevronDown className="h-5 w-5 text-gray-500 transition-transform" />
+                  ) : (
+                    <ChevronRight className="h-5 w-5 text-gray-500 transition-transform" />
+                  )}
+                </button>
+
+                <div
+                  id="profile-submenu"
+                  className="grid grid-cols-1"
+                  style={{
+                    overflow: "hidden",
+                    transition: "max-height 220ms ease",
+                    maxHeight: profileOpen ? 320 : 0,
+                  }}
+                >
+                  <button
+                    onClick={() => handleNavigation("/profile/account")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                  >
+                    <UserCog className="h-4 w-4 text-primary-700" />
+                    {t("account", { defaultValue: "Account" })}
+                  </button>
+                  <button
+                    onClick={() => handleNavigation("/profile/favorites")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                  >
+                    <Heart className="h-4 w-4 text-primary-700" />
+                    {t("favorites", { defaultValue: "Favorites" })}
+                  </button>
+                  <button
+                    onClick={() => handleNavigation("/profile/reservations")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                  >
+                    <CalendarDays className="h-4 w-4 text-primary-700" />
+                    {t("reservations", { defaultValue: "Reservations" })}
+                  </button>
+                  <button
+                    onClick={() => handleNavigation("/profile/reviews")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                  >
+                    <MessageSquare className="h-4 w-4 text-primary-700" />
+                    {t("reviews", { defaultValue: "Reviews" })}
+                  </button>
+                  <button
+                    onClick={() => handleNavigation("/profile/settings")}
+                    className="flex items-center gap-2 px-4 py-2.5 text-sm text-gray-700 hover:bg-white transition text-left"
+                  >
+                    <SettingsIcon className="h-4 w-4 text-primary-700" />
+                    {t("settings", { defaultValue: "Settings" })}
+                  </button>
+                </div>
+              </div>
 
               {user.role === "ADMIN" && (
                 <button
@@ -142,39 +215,61 @@ const SideMenu: React.FC<SideMenuProps> = ({
                   {t("adminPage")}
                 </button>
               )}
-
-              <button
-                onClick={async () => {
-                  await onLogout();
-                  onClose();
-                }}
-                className="w-full bg-red-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-700 transition"
-              >
-                {t("logout")}
-              </button>
             </div>
           ) : (
-            <div className="space-y-4 text-center">
-              <p className="text-sm text-gray-700">{t("pleaseLogin")}</p>
-              <button
-                onClick={() => handleNavigation("/login")}
-                className="text-primary-700 underline font-medium"
-              >
-                {t("login")}
-              </button>
+            <div className="text-left">
+              {locale === "ko" ? (
+                <p className="text-sm text-gray-800 leading-6">
+                  서비스 이용을 위해{" "}
+                  <Link
+                    href={`/${locale}/login`}
+                    className="underline underline-offset-4 decoration-1 text-primary-700 hover:text-primary-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-sm"
+                    aria-label="로그인 페이지로 이동"
+                  >
+                    로그인
+                  </Link>
+                  이 필요합니다.
+                </p>
+              ) : (
+                <p className="text-sm text-gray-800 leading-6">
+                  To continue, please{" "}
+                  <Link
+                    href={`/${locale}/login`}
+                    className="underline underline-offset-4 decoration-1 text-primary-700 hover:text-primary-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded-sm"
+                    aria-label="Go to login page"
+                  >
+                    log in
+                  </Link>
+                  .
+                </p>
+              )}
             </div>
           )}
 
           <div className="pt-6 border-t border-gray-200">
             <button
               onClick={() => handleNavigation("/")}
-              className="block w-full text-left text-sm text-gray-700 hover:text-primary-700"
+              className="flex items-center gap-2 w-full text-left text-sm text-gray-700 hover:text-primary-700 hover:bg-white rounded-md px-3 py-2 transition"
             >
-              <Home className="inline-block text-primary-800 mr-2" />
+              <Home className="h-5 w-5 text-primary-800" />
               {t("home")}
             </button>
           </div>
         </div>
+
+        {user && (
+          <div className="shrink-0 border-t border-gray-200 p-4 pt-3">
+            <button
+              onClick={async () => {
+                await onLogout();
+                onClose();
+              }}
+              className="w-full bg-red-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 transition"
+            >
+              {t("logout")}
+            </button>
+          </div>
+        )}
       </aside>
     </>,
     document.body


### PR DESCRIPTION
# Pull Request

## Description  
- Implemented SideMenu.tsx as a separate, portal-based right drawer (with overlay, safe-area paddings, and smooth slide animation).
- Integrated the side menu into HeaderBar.tsx via a hamburger button.
- Added Home action (always visible).
- Added user-conditional content:
  - Logged-out: professional inline copy with an underlined login link that routes to /${locale}/login.
  - Logged-in: greeting using i18n (greetingInline) and a Profile collapsible section with sub-links:
    - Account /profile/account
    - Favorites /profile/favorites
    - Reservations /profile/reservations
    - Reviews /profile/reviews
    - Settings /profile/settings
  - Admin button shown when user.role === "ADMIN".
  - Logout button pinned at the bottom.
- Added Support collapsible section:
  - FAQ /help
  - Contact /help/contact
- Added Dark/Light mode toggle (Sun/Moon icon) next to the close button in the drawer header using next-themes.
- Polished UI/UX:
  - Unified drawer background to #FAFAFA.
  - Hover/active states, focus rings, underline offsets, and accessible labels.
  - Drawer closes on route change, outside click, and Esc.
  - Auto-expand Profile when on /profile*, Support when on /help*.
- Added/updated i18n keys in header namespace:
greetingInline, home, profile, account, favorites, reservations, reviews, settings, adminPage, support, faq, contact, closeMenu, lightMode, darkMode.

## Why  
- Replace the old header dropdown with a modern, mobile-friendly side drawer that cleanly separates navigation from account actions.
- Provide a consistent, accessible navigation experience with clear logged-in/logged-out states.
- Add Support access points and a global theme toggle for better usability.

## Testing  
Manual verification steps:
1. Run the app locally and open the header hamburger button → side drawer slides in from the right with overlay.
2. Close interactions:
  - Click outside overlay → closes.
  - Press Esc → closes.
  - Navigate to any route → closes automatically.
3. Logged-out state:
  - See inline sentence with underlined “로그인 / log in” link.
  - Clicking it routes to /${locale}/login.
4. Logged-in state:
  - Greeting shows as {{nickname}}님 안녕하세요 (or English equivalent).
  - Home button is always visible and routes to /${locale}/.
  - Profile row toggles sub-menu; each item routes correctly.
  - If user.role === "ADMIN", Admin button appears and routes to /${locale}/admin.
  - Logout button stays pinned at the bottom and logs out + routes home.
5. Support:
  - Toggling shows FAQ and Contact; correct routing to /help and /help/contact.
  - Visiting /help* auto-expands this section.
6. Theme toggle:
  - Sun/Moon button switches between light/dark (no hydration flicker due to mounted check).
7. A11y/Styling:
  - Focus rings on interactive elements; hover states; underline offset on links.
  - Drawer background is #FAFAFA throughout.

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [x] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
