### PR TITLE
Feat/support

### DIFF
--- a/public/locales/en/contact.json
+++ b/public/locales/en/contact.json
@@ -1,0 +1,36 @@
+{
+  "contact": {
+    "title": "Support",
+    "createButton": "New inquiry",
+    "createTitle": "Create a new inquiry",
+    "loginRequired": "Please log in to use support features.",
+    "successBody": "Your inquiry has been submitted successfully.",
+    "form": {
+      "required": "Please fill in all required fields.",
+      "nameLabel": "Name",
+      "namePlaceholder": "Your name",
+      "submit": "Submit"
+    }
+  },
+  "support": {
+    "form": {
+      "questionLabel": "Question",
+      "questionPlaceholder": "Write your question here..."
+    },
+    "status": {
+      "pending": "Pending",
+      "answered": "Answered"
+    },
+    "empty": "No inquiries yet.",
+    "answerPreview": "A:",
+    "waitingForAnswer": "Awaiting admin response.",
+    "detailTitle": "Support Detail",
+    "submittedAt": "Submitted at",
+    "answeredAt": "Answered at",
+    "notFound": "Ticket not found."
+  },
+  "common": {
+    "cancel": "Cancel"
+  },
+  "loading": "Loading..."
+}

--- a/public/locales/en/contact.json
+++ b/public/locales/en/contact.json
@@ -7,8 +7,8 @@
     "successBody": "Your inquiry has been submitted successfully.",
     "form": {
       "required": "Please fill in all required fields.",
-      "nameLabel": "Name",
-      "namePlaceholder": "Your name",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Enter a title",
       "submit": "Submit"
     }
   },

--- a/public/locales/ko/contact.json
+++ b/public/locales/ko/contact.json
@@ -1,0 +1,36 @@
+{
+  "contact": {
+    "title": "문의",
+    "createButton": "문의하기",
+    "createTitle": "새 문의 작성",
+    "loginRequired": "로그인이 필요합니다.",
+    "successBody": "문의가 정상적으로 접수되었습니다.",
+    "form": {
+      "required": "필수 항목을 입력해 주세요.",
+      "nameLabel": "이름",
+      "namePlaceholder": "이름을 입력하세요",
+      "submit": "제출"
+    }
+  },
+  "support": {
+    "form": {
+      "questionLabel": "문의 내용",
+      "questionPlaceholder": "문의 내용을 입력해 주세요..."
+    },
+    "status": {
+      "pending": "답변 대기",
+      "answered": "답변 완료"
+    },
+    "empty": "등록된 문의가 없습니다.",
+    "answerPreview": "A:",
+    "waitingForAnswer": "관리자 답변을 기다리고 있습니다.",
+    "detailTitle": "문의 상세",
+    "submittedAt": "제출 일시",
+    "answeredAt": "답변 일시",
+    "notFound": "해당 문의를 찾을 수 없습니다."
+  },
+  "common": {
+    "cancel": "취소"
+  },
+  "loading": "로딩 중..."
+}

--- a/public/locales/ko/contact.json
+++ b/public/locales/ko/contact.json
@@ -7,8 +7,8 @@
     "successBody": "문의가 정상적으로 접수되었습니다.",
     "form": {
       "required": "필수 항목을 입력해 주세요.",
-      "nameLabel": "이름",
-      "namePlaceholder": "이름을 입력하세요",
+      "titleLabel": "제목",
+      "titlePlaceholder": "제목을 입력하세요",
       "submit": "제출"
     }
   },

--- a/src/app/[locale]/admin/page.tsx
+++ b/src/app/[locale]/admin/page.tsx
@@ -90,6 +90,15 @@ const AdminPage = () => {
             iconPath="M12 8c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zm0 2c-2.21 0-4 1.79-4 4v4h8v-4c0-2.21-1.79-4-4-4z"
           />
         </Link>
+
+        <Link href={`/${locale}/admin/support`}>
+          <AdminCard
+            iconColor="text-teal-500"
+            title="문의 관리"
+            description="사용자 문의 확인 및 답변"
+            iconPath="M7 8h10M7 12h6m-6 8l-4-4V5a2 2 0 012-2h10l4 4v9a2 2 0 01-2 2H7z"
+          />
+        </Link>
       </section>
     </div>
   );

--- a/src/app/[locale]/admin/support/[id]/page.tsx
+++ b/src/app/[locale]/admin/support/[id]/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
+import { patchSupport } from "@/lib/admin/support/supportThunk";
+
+export default function AdminSupportDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = Number(params.id);
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+
+  const { list, state } = useAppSelector((s: any) => s["admin/support"]);
+  const itemFromList = useMemo(
+    () => list.find((x: any) => x.id === id),
+    [list, id]
+  );
+
+  const [answer, setAnswer] = useState<string>(itemFromList?.answer ?? "");
+  const [status, setStatus] = useState<"PENDING" | "ANSWERED">(
+    itemFromList?.status ?? "PENDING"
+  );
+
+  useEffect(() => {
+    if (itemFromList) {
+      setAnswer(itemFromList.answer ?? "");
+      setStatus(itemFromList.status);
+    }
+  }, [itemFromList]);
+
+  const title = (itemFromList as any)?.title ?? (itemFromList as any)?.name ?? "(제목 없음)";
+
+  const onSave = async () => {
+    try {
+      await dispatch(
+        patchSupport({
+          id,
+          answer,
+          status,
+        })
+      ).unwrap();
+      alert("저장되었습니다.");
+      router.push("/admin/support");
+    } catch {
+      alert("저장에 실패했습니다.");
+    }
+  };
+
+  if (Number.isNaN(id)) {
+    return (
+      <div className="max-w-3xl mx-auto p-6 text-red-600">
+        잘못된 ID 입니다.
+      </div>
+    );
+  }
+
+  if (!itemFromList && state === "loading") {
+    return (
+      <div className="max-w-3xl mx-auto p-6 text-gray-600">로딩 중...</div>
+    );
+  }
+
+  if (!itemFromList && state !== "loading") {
+    return (
+      <div className="max-w-3xl mx-auto p-6 text-gray-600">
+        현재 상태에서 해당 문의를 찾을 수 없습니다. 목록에서 다시 시도해 주세요.
+        <div className="mt-4">
+          <button
+            className="border rounded px-3 py-1"
+            onClick={() => router.push("/admin/support")}
+          >
+            목록으로
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const it = itemFromList!;
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <button
+        className="text-sm text-gray-600 hover:underline mb-4"
+        onClick={() => router.push("/admin/support")}
+      >
+        ← 목록으로
+      </button>
+
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <h1 className="text-2xl font-bold break-words">{title}</h1>
+        <span
+          className={
+            "text-xs px-2 py-1 rounded border " +
+            (it.status === "ANSWERED"
+              ? "bg-green-50 text-green-700 border-green-200"
+              : "bg-amber-50 text-amber-700 border-amber-200")
+          }
+        >
+          {it.status === "ANSWERED" ? "답변 완료" : "답변 대기"}
+        </span>
+      </div>
+
+      <section className="rounded-xl border p-4 mb-6">
+        <div className="text-sm font-semibold text-gray-500 mb-2">Q</div>
+        <div className="prose whitespace-pre-wrap break-words">
+          {it.question}
+        </div>
+        <div className="text-xs text-gray-400 mt-2">
+          제출 일시: {new Date(it.createdAt).toLocaleString()}
+        </div>
+      </section>
+
+      <section className="rounded-xl border p-4">
+        <div className="text-sm font-semibold text-gray-500 mb-2">A</div>
+        <textarea
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          rows={8}
+          className="w-full border rounded-lg px-3 py-2"
+          placeholder="답변 내용을 입력하세요..."
+        />
+        <div className="flex items-center justify-between mt-3">
+          <div className="flex items-center gap-2">
+            <label className="text-sm text-gray-600">상태</label>
+            <select
+              className="border rounded px-2 py-1"
+              value={status}
+              onChange={(e) =>
+                setStatus(e.target.value as "PENDING" | "ANSWERED")
+              }
+            >
+              <option value="PENDING">답변 대기</option>
+              <option value="ANSWERED">답변 완료</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              className="border rounded px-4 py-2 hover:bg-gray-50"
+              onClick={() => router.push("/admin/support")}
+            >
+              취소
+            </button>
+            <button
+              className="bg-primary-700 text-white rounded px-4 py-2 hover:bg-primary-800"
+              onClick={onSave}
+            >
+              저장
+            </button>
+          </div>
+        </div>
+
+        <div className="text-xs text-gray-400 mt-3">
+          답변 일시: {it.answeredAt ? new Date(it.answeredAt).toLocaleString() : "-"}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/support/[id]/page.tsx
+++ b/src/app/[locale]/admin/support/[id]/page.tsx
@@ -4,12 +4,14 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { patchSupport } from "@/lib/admin/support/supportThunk";
+import { useLocale } from "@/utils/useLocale";
 
 export default function AdminSupportDetailPage() {
   const params = useParams<{ id: string }>();
   const id = Number(params.id);
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { list, state } = useAppSelector((s: any) => s["admin/support"]);
   const itemFromList = useMemo(
@@ -41,7 +43,7 @@ export default function AdminSupportDetailPage() {
         })
       ).unwrap();
       alert("저장되었습니다.");
-      router.push("/admin/support");
+      router.push(`${locale}/admin/support`);
     } catch {
       alert("저장에 실패했습니다.");
     }
@@ -68,7 +70,7 @@ export default function AdminSupportDetailPage() {
         <div className="mt-4">
           <button
             className="border rounded px-3 py-1"
-            onClick={() => router.push("/admin/support")}
+            onClick={() => router.push(`${locale}/admin/support`)}
           >
             목록으로
           </button>
@@ -83,7 +85,7 @@ export default function AdminSupportDetailPage() {
     <div className="max-w-3xl mx-auto p-6">
       <button
         className="text-sm text-gray-600 hover:underline mb-4"
-        onClick={() => router.push("/admin/support")}
+        onClick={() => router.push(`${locale}/admin/support`)}
       >
         ← 목록으로
       </button>

--- a/src/app/[locale]/admin/support/page.tsx
+++ b/src/app/[locale]/admin/support/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
+import { fetchAllSupports } from "@/lib/admin/support/supportThunk";
+import { useRouter } from "next/navigation";
+
+export default function AdminSupportListPage() {
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+
+  const { list, total, page, limit, state, error } = useAppSelector(
+    (s: any) => s["admin/support"]
+  );
+
+  const [curPage, setCurPage] = useState<number>(page || 1);
+  const [curLimit, setCurLimit] = useState<number>(limit || 20);
+
+  useEffect(() => {
+    dispatch(fetchAllSupports({ page: curPage, limit: curLimit }));
+  }, [dispatch, curPage, curLimit]);
+
+  const totalPages = Math.max(1, Math.ceil(total / curLimit));
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">문의 목록</h1>
+        <div className="flex items-center gap-3">
+          <label className="text-sm text-gray-600">페이지당</label>
+          <select
+            className="border rounded px-2 py-1"
+            value={curLimit}
+            onChange={(e) => {
+              setCurLimit(Number(e.target.value));
+              setCurPage(1);
+            }}
+          >
+            {[10, 20, 50, 100].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="rounded-lg border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr className="text-left">
+              <th className="px-4 py-2 w-20">ID</th>
+              <th className="px-4 py-2">제목</th>
+              <th className="px-4 py-2">상태</th>
+              <th className="px-4 py-2">생성일</th>
+              <th className="px-4 py-2">답변일</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state === "loading" && (
+              <tr>
+                <td className="px-4 py-6 text-center" colSpan={5}>
+                  로딩 중...
+                </td>
+              </tr>
+            )}
+            {state === "failed" && (
+              <tr>
+                <td className="px-4 py-6 text-center text-red-600" colSpan={5}>
+                  {error ?? "불러오기에 실패했습니다."}
+                </td>
+              </tr>
+            )}
+            {state !== "loading" && list.length === 0 && (
+              <tr>
+                <td className="px-4 py-6 text-center text-gray-600" colSpan={5}>
+                  등록된 문의가 없습니다.
+                </td>
+              </tr>
+            )}
+            {list.map((it: any) => (
+              <tr
+                key={it.id}
+                className="hover:bg-gray-50 cursor-pointer"
+                onClick={() => router.push(`/admin/support/${it.id}`)}
+              >
+                <td className="px-4 py-2">{it.id}</td>
+                <td className="px-4 py-2">
+                  <div className="font-medium line-clamp-1">
+                    {it.title ?? it.name ?? "(제목 없음)"}
+                  </div>
+                  <div className="text-xs text-gray-500 line-clamp-1">
+                    {it.question}
+                  </div>
+                </td>
+                <td className="px-4 py-2">
+                  <span
+                    className={
+                      "text-xs px-2 py-1 rounded border " +
+                      (it.status === "ANSWERED"
+                        ? "bg-green-50 text-green-700 border-green-200"
+                        : "bg-amber-50 text-amber-700 border-amber-200")
+                    }
+                  >
+                    {it.status === "ANSWERED" ? "답변 완료" : "답변 대기"}
+                  </span>
+                </td>
+                <td className="px-4 py-2">
+                  {new Date(it.createdAt).toLocaleString()}
+                </td>
+                <td className="px-4 py-2">
+                  {it.answeredAt ? new Date(it.answeredAt).toLocaleString() : "-"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between mt-4">
+        <div className="text-sm text-gray-600">
+          총 {total.toLocaleString()}건 • {curPage} / {totalPages}페이지
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            className="border rounded px-3 py-1 disabled:opacity-50"
+            onClick={() => setCurPage((p) => Math.max(1, p - 1))}
+            disabled={curPage <= 1}
+          >
+            이전
+          </button>
+          <button
+            className="border rounded px-3 py-1 disabled:opacity-50"
+            onClick={() => setCurPage((p) => Math.min(totalPages, p + 1))}
+            disabled={curPage >= totalPages}
+          >
+            다음
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/support/page.tsx
+++ b/src/app/[locale]/admin/support/page.tsx
@@ -4,10 +4,12 @@ import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@/lib/store/hooks";
 import { fetchAllSupports } from "@/lib/admin/support/supportThunk";
 import { useRouter } from "next/navigation";
+import { useLocale } from "@/utils/useLocale";
 
 export default function AdminSupportListPage() {
   const dispatch = useAppDispatch();
   const router = useRouter();
+  const locale = useLocale();
 
   const { list, total, page, limit, state, error } = useAppSelector(
     (s: any) => s["admin/support"]
@@ -82,7 +84,7 @@ export default function AdminSupportListPage() {
               <tr
                 key={it.id}
                 className="hover:bg-gray-50 cursor-pointer"
-                onClick={() => router.push(`/admin/support/${it.id}`)}
+                onClick={() => router.push(`${locale}/admin/support/${it.id}`)}
               >
                 <td className="px-4 py-2">{it.id}</td>
                 <td className="px-4 py-2">

--- a/src/app/[locale]/help/contact/[id]/page.tsx
+++ b/src/app/[locale]/help/contact/[id]/page.tsx
@@ -1,0 +1,131 @@
+// app/[locale]/help/contact/[id]/page.tsx
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams, useRouter } from "next/navigation";
+import { useLocale } from "@/utils/useLocale";
+import { useAppSelector } from "@/lib/store/hooks";
+import toast from "react-hot-toast";
+import { useGetSupportByIdQuery } from "@/lib/support/supportApi";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+
+type Ticket = {
+  id: number;
+  title?: string;      
+  name?: string;       
+  question: string;
+  answer?: string | null;
+  status: "PENDING" | "ANSWERED";
+  createdAt: string;
+  updatedAt: string;
+  answeredAt?: string | null;
+};
+
+export default function ContactDetailPage() {
+  const { t } = useTranslation("contact");
+  const router = useRouter();
+  const locale = useLocale();
+  const params = useParams<{ id: string }>();
+  const user = useAppSelector((s) => s.auth.user);
+
+  const idNum = Number(params.id);
+  const redirected = useRef(false);
+  const backUrl = `/${locale}/help/contact`;
+  const loginUrl = `/${locale}/login?next=${encodeURIComponent(
+    `/${locale}/help/contact/${params.id}`
+  )}`;
+
+  useEffect(() => {
+    if (!user && !redirected.current) {
+      redirected.current = true;
+      toast.error(t("contact.loginRequired") as string);
+      router.replace(loginUrl);
+    }
+  }, [user, router, loginUrl, t]);
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+  } = useGetSupportByIdQuery(idNum, { skip: !user || Number.isNaN(idNum) });
+
+  useEffect(() => {
+    const e = error as FetchBaseQueryError | undefined;
+    if (!e || redirected.current) return;
+    if ("status" in (e ?? {}) && e?.status === 401) {
+      redirected.current = true;
+      toast.error(t("contact.loginRequired") as string);
+      router.replace(loginUrl);
+    }
+  }, [error, router, loginUrl, t]);
+
+  const ticket = data as Ticket | undefined;
+  const title = ticket?.title || ticket?.name || t("support.detailTitle");
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-4">
+      <button
+        onClick={() => router.push(backUrl)}
+        className="text-sm text-gray-600 hover:underline mb-6"
+      >
+        ← {t("common.cancel")}
+      </button>
+
+      {isLoading || isFetching ? (
+        <div className="text-gray-600">{t("loading")}</div>
+      ) : !ticket ? (
+        <div className="text-gray-600">{t("support.notFound")}</div>
+      ) : (
+        <div className="space-y-6">
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="text-2xl font-bold break-words">{title}</h1>
+            <span
+              className={
+                "text-xs px-2 py-1 rounded border shrink-0 " +
+                (ticket.status === "ANSWERED"
+                  ? "bg-green-50 text-green-700 border-green-200"
+                  : "bg-amber-50 text-amber-700 border-amber-200")
+              }
+            >
+              {t(`support.status.${ticket.status.toLowerCase()}`)}
+            </span>
+          </div>
+
+          <section className="rounded-xl border p-4">
+            <div className="text-sm font-semibold text-gray-500 mb-2">Q</div>
+            <div className="prose whitespace-pre-wrap break-words">
+              {ticket.question}
+            </div>
+            <div className="text-xs text-gray-400 mt-2">
+              {t("support.submittedAt")}:{" "}
+              {new Date(ticket.createdAt).toLocaleString()}
+            </div>
+          </section>
+
+          <section className="rounded-xl border p-4">
+            <div className="text-sm font-semibold text-gray-500 mb-2">A</div>
+            {ticket.answer ? (
+              <>
+                <div className="prose whitespace-pre-wrap break-words">
+                  {ticket.answer}
+                </div>
+                <div className="text-xs text-gray-400 mt-2">
+                  {t("support.answeredAt")}:{" "}
+                  {ticket.answeredAt
+                    ? new Date(ticket.answeredAt).toLocaleString()
+                    : "-"}
+                </div>
+              </>
+            ) : (
+              <div className="text-gray-500">
+                {t("support.waitingForAnswer")}
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/help/contact/page.tsx
+++ b/src/app/[locale]/help/contact/page.tsx
@@ -1,75 +1,205 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useRouter } from "next/navigation";
+import { useLocale } from "@/utils/useLocale";
+import { useAppSelector } from "@/lib/store/hooks";
+import toast from "react-hot-toast";
+import {
+  useGetMySupportsQuery,
+  useCreateSupportMutation,
+} from "@/lib/support/supportApi";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
-const ContactPage = () => {
-  const { t } = useTranslation("help");
-  const [form, setForm] = useState({ name: "", email: "", message: "" });
-  const [submitted, setSubmitted] = useState(false);
+type SupportItem = {
+  id: number;
+  question: string;
+  answer?: string | null;
+  status: "PENDING" | "ANSWERED";
+  createdAt: string;
+  updatedAt: string;
+  answeredAt?: string | null;
+};
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
+const ContactListPage = () => {
+  const { t } = useTranslation("contact");
+  const router = useRouter();
+  const locale = useLocale();
+  const user = useAppSelector((s) => s.auth.user);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const [openCreate, setOpenCreate] = useState(false);
+  const [form, setForm] = useState({ name: "", question: "" });
+
+  const redirected = useRef(false);
+  const loginUrl = `/${locale}/login?next=${encodeURIComponent(
+    `/${locale}/help/support`
+  )}`;
+
+  useEffect(() => {
+    if (!user && !redirected.current) {
+      redirected.current = true;
+      toast.error(t("contact.loginRequired") as string);
+      router.replace(loginUrl);
+    }
+  }, [user, router, loginUrl, t]);
+
+  const {
+    data,
+    isLoading,
+    error,
+  } = useGetMySupportsQuery(
+    { page: 1, pageSize: 10 },
+    { skip: !user }
+  );
+
+  useEffect(() => {
+    const e = error as FetchBaseQueryError | undefined;
+    if (!e || redirected.current) return;
+    if ("status" in (e ?? {}) && e?.status === 401) {
+      redirected.current = true;
+      toast.error(t("contact.loginRequired") as string);
+      router.replace(loginUrl);
+    }
+  }, [error, router, loginUrl, t]);
+
+  const list = (data?.items ?? []) as SupportItem[];
+
+  const [createSupport, { isLoading: creating }] = useCreateSupportMutation();
+
+  const onSubmitCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: 여기에 실제 메일 전송 API 연결
-    setSubmitted(true);
+    const name = form.name.trim();
+    const question = form.question.trim();
+    if (!name || !question) {
+      toast.error(t("contact.form.required") as string);
+      return;
+    }
+    try {
+      await createSupport({ name, question }).unwrap();
+      toast.success(t("contact.successBody") as string);
+      setOpenCreate(false);
+      setForm({ name: "", question: "" });
+    } catch (err) {
+      const e = err as FetchBaseQueryError;
+      if (e?.status === 401 && !redirected.current) {
+        redirected.current = true;
+        toast.error(t("contact.loginRequired") as string);
+        router.replace(loginUrl);
+      } else {
+        toast.error("Failed");
+      }
+    }
   };
-
-  if (submitted) {
-    return (
-      <div className="max-w-lg mx-auto py-10 px-4 text-center">
-        <h1 className="text-2xl font-bold mb-4">{t("contact.successTitle")}</h1>
-        <p className="text-gray-700">{t("contact.successBody")}</p>
-      </div>
-    );
-  }
 
   return (
-    <div className="max-w-lg mx-auto py-10 px-4">
-      <h1 className="text-2xl font-bold mb-6">{t("contact.title")}</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="text"
-          name="name"
-          placeholder={t("contact.form.namePlaceholder") as string}
-          value={form.name}
-          onChange={handleChange}
-          className="w-full border rounded-lg px-4 py-2"
-          required
-          aria-label={t("contact.form.nameLabel")}
-        />
-        <input
-          type="email"
-          name="email"
-          placeholder={t("contact.form.emailPlaceholder") as string}
-          value={form.email}
-          onChange={handleChange}
-          className="w-full border rounded-lg px-4 py-2"
-          required
-          aria-label={t("contact.form.emailLabel")}
-        />
-        <textarea
-          name="message"
-          placeholder={t("contact.form.messagePlaceholder") as string}
-          value={form.message}
-          onChange={handleChange}
-          rows={5}
-          className="w-full border rounded-lg px-4 py-2"
-          required
-          aria-label={t("contact.form.messageLabel")}
-        />
+    <div className="max-w-3xl mx-auto py-10 px-4">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">{t("contact.title")}</h1>
         <button
-          type="submit"
-          className="w-full bg-primary-700 text-white py-2 rounded-lg hover:bg-primary-800 transition"
+          className="px-4 py-2 rounded-lg bg-primary-700 text-white hover:bg-primary-800 transition"
+          onClick={() => setOpenCreate(true)}
         >
-          {t("contact.form.submit")}
+          {t("contact.createButton")}
         </button>
-      </form>
+      </div>
+
+      {isLoading ? (
+        <div className="text-gray-600">{t("loading")}</div>
+      ) : !user ? (
+        <div className="text-gray-600">{t("contact.loginRequired")}</div>
+      ) : list.length === 0 ? (
+        <div className="text-gray-600">{t("support.empty")}</div>
+      ) : (
+        <ul className="divide-y rounded-lg border">
+          {list.map((it) => (
+            <li
+              key={it.id}
+              className="p-4 cursor-pointer hover:bg-gray-50"
+              onClick={() => router.push(`/${locale}/help/support/${it.id}`)}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-medium line-clamp-1">{it.question}</div>
+                <span
+                  className={
+                    "text-xs px-2 py-1 rounded border shrink-0 " +
+                    (it.status === "ANSWERED"
+                      ? "bg-green-50 text-green-700 border-green-200"
+                      : "bg-amber-50 text-amber-700 border-amber-200")
+                  }
+                >
+                  {t(`support.status.${it.status.toLowerCase()}`)}
+                </span>
+              </div>
+              <div className="text-xs text-gray-500 mt-1">
+                {new Date(it.createdAt).toLocaleString()}
+              </div>
+              {it.answer ? (
+                <div className="text-sm text-gray-700 mt-2 line-clamp-2">
+                  {t("support.answerPreview")} {it.answer}
+                </div>
+              ) : (
+                <div className="text-sm text-gray-500 mt-2">
+                  {t("support.waitingForAnswer")}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {openCreate && user && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white w-full max-w-lg rounded-2xl p-6 shadow-lg">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-semibold">{t("contact.createTitle")}</h2>
+              <button onClick={() => setOpenCreate(false)} aria-label="Close">
+                ✕
+              </button>
+            </div>
+            <form onSubmit={onSubmitCreate} className="space-y-4">
+              <input
+                type="text"
+                name="name"
+                placeholder={t("contact.form.namePlaceholder") as string}
+                value={form.name}
+                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                className="w-full border rounded-lg px-4 py-2"
+                required
+                aria-label={t("contact.form.nameLabel")}
+              />
+              <textarea
+                name="question"
+                placeholder={t("support.form.questionPlaceholder") as string}
+                value={form.question}
+                onChange={(e) => setForm((f) => ({ ...f, question: e.target.value }))}
+                rows={6}
+                className="w-full border rounded-lg px-4 py-2"
+                required
+                aria-label={t("support.form.questionLabel")}
+              />
+              <div className="flex gap-2">
+                <button
+                  type="submit"
+                  disabled={creating}
+                  className="flex-1 bg-primary-700 text-white py-2 rounded-lg hover:bg-primary-800 transition disabled:opacity-60"
+                >
+                  {t("contact.form.submit")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setOpenCreate(false)}
+                  className="flex-1 border py-2 rounded-lg hover:bg-gray-50"
+                >
+                  {t("common.cancel")}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
-export default ContactPage;
+export default ContactListPage;

--- a/src/app/[locale]/help/contact/page.tsx
+++ b/src/app/[locale]/help/contact/page.tsx
@@ -14,6 +14,7 @@ import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 
 type SupportItem = {
   id: number;
+  name: string;
   question: string;
   answer?: string | null;
   status: "PENDING" | "ANSWERED";
@@ -29,7 +30,7 @@ const ContactListPage = () => {
   const user = useAppSelector((s) => s.auth.user);
 
   const [openCreate, setOpenCreate] = useState(false);
-  const [form, setForm] = useState({ name: "", question: "" });
+  const [form, setForm] = useState({ title: "", question: "" });
 
   const redirected = useRef(false);
   const loginUrl = `/${locale}/login?next=${encodeURIComponent(
@@ -44,11 +45,7 @@ const ContactListPage = () => {
     }
   }, [user, router, loginUrl, t]);
 
-  const {
-    data,
-    isLoading,
-    error,
-  } = useGetMySupportsQuery(
+  const { data, isLoading, error } = useGetMySupportsQuery(
     { page: 1, pageSize: 10 },
     { skip: !user }
   );
@@ -69,17 +66,17 @@ const ContactListPage = () => {
 
   const onSubmitCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    const name = form.name.trim();
+    const title = form.title.trim();
     const question = form.question.trim();
-    if (!name || !question) {
+    if (!title || !question) {
       toast.error(t("contact.form.required") as string);
       return;
     }
     try {
-      await createSupport({ name, question }).unwrap();
+      await createSupport({ name: title, question }).unwrap();
       toast.success(t("contact.successBody") as string);
       setOpenCreate(false);
-      setForm({ name: "", question: "" });
+      setForm({ title: "", question: "" });
     } catch (err) {
       const e = err as FetchBaseQueryError;
       if (e?.status === 401 && !redirected.current) {
@@ -119,7 +116,7 @@ const ContactListPage = () => {
               onClick={() => router.push(`/${locale}/help/support/${it.id}`)}
             >
               <div className="flex items-center justify-between gap-3">
-                <div className="font-medium line-clamp-1">{it.question}</div>
+                <div className="font-medium line-clamp-1">{it.name}</div>
                 <span
                   className={
                     "text-xs px-2 py-1 rounded border shrink-0 " +
@@ -152,7 +149,9 @@ const ContactListPage = () => {
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
           <div className="bg-white w-full max-w-lg rounded-2xl p-6 shadow-lg">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-xl font-semibold">{t("contact.createTitle")}</h2>
+              <h2 className="text-xl font-semibold">
+                {t("contact.createTitle")}
+              </h2>
               <button onClick={() => setOpenCreate(false)} aria-label="Close">
                 ✕
               </button>
@@ -160,19 +159,29 @@ const ContactListPage = () => {
             <form onSubmit={onSubmitCreate} className="space-y-4">
               <input
                 type="text"
-                name="name"
-                placeholder={t("contact.form.namePlaceholder") as string}
-                value={form.name}
-                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                name="title"
+                placeholder={
+                  (t("contact.form.titlePlaceholder") as string) ||
+                  ((t("contact.form.namePlaceholder") as string) ?? "")
+                }
+                value={form.title}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, title: e.target.value }))
+                }
                 className="w-full border rounded-lg px-4 py-2"
                 required
-                aria-label={t("contact.form.nameLabel")}
+                aria-label={
+                  (t("contact.form.titleLabel") as string) ||
+                  ((t("contact.form.nameLabel") as string) ?? "")
+                }
               />
               <textarea
                 name="question"
                 placeholder={t("support.form.questionPlaceholder") as string}
                 value={form.question}
-                onChange={(e) => setForm((f) => ({ ...f, question: e.target.value }))}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, question: e.target.value }))
+                }
                 rows={6}
                 className="w-full border rounded-lg px-4 py-2"
                 required

--- a/src/lib/admin/support/supportSlice.ts
+++ b/src/lib/admin/support/supportSlice.ts
@@ -1,0 +1,75 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Support, SupportPagination } from "@/types/support";
+import { fetchAllSupports, patchSupport } from "./supportThunk";
+
+interface AdminSupportState {
+  list: Support[];
+  total: number;
+  page: number;
+  limit: number;
+  current: Support | null;
+  state: "idle" | "loading" | "succeeded" | "failed";
+  error: string | null;
+}
+
+const initialState: AdminSupportState = {
+  list: [],
+  total: 0,
+  page: 1,
+  limit: 20,
+  current: null,
+  state: "idle",
+  error: null,
+};
+
+const adminSupportSlice = createSlice({
+  name: "admin/support",
+  initialState,
+  reducers: {
+    clearCurrentSupport(state) {
+      state.current = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchAllSupports.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        fetchAllSupports.fulfilled,
+        (state, action: PayloadAction<SupportPagination>) => {
+          state.state = "succeeded";
+          state.list = action.payload.data;
+          state.total = action.payload.total;
+          state.page = action.payload.page;
+          state.limit = action.payload.limit;
+        }
+      )
+      .addCase(fetchAllSupports.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      })
+      .addCase(patchSupport.pending, (state) => {
+        state.state = "loading";
+        state.error = null;
+      })
+      .addCase(
+        patchSupport.fulfilled,
+        (state, action: PayloadAction<Support>) => {
+          state.state = "succeeded";
+          const idx = state.list.findIndex((s) => s.id === action.payload.id);
+          if (idx !== -1) state.list[idx] = action.payload;
+          if (state.current?.id === action.payload.id)
+            state.current = action.payload;
+        }
+      )
+      .addCase(patchSupport.rejected, (state, action) => {
+        state.state = "failed";
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export const { clearCurrentSupport } = adminSupportSlice.actions;
+export default adminSupportSlice.reducer;

--- a/src/lib/admin/support/supportThunk.ts
+++ b/src/lib/admin/support/supportThunk.ts
@@ -1,0 +1,61 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { RootState } from "@/lib/store/store";
+import { logout } from "@/lib/auth/authSlice";
+import { Support, SupportPagination, SupportStatus } from "@/types/support";
+
+export const fetchAllSupports = createAsyncThunk<
+  SupportPagination,
+  { page?: number; limit?: number },
+  { rejectValue: string; state: RootState }
+>(
+  "admin/support/fetchList",
+  async ({ page = 1, limit = 20 }, { dispatch, rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/support`,
+        {
+          params: { page, pageSize: limit },
+          headers: { Authorization: `Bearer ${token}` },
+          withCredentials: true,
+        }
+      );
+      const { items, total, page: p, pageSize } = res.data;
+      return { data: items as Support[], total, page: p, limit: pageSize };
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        if (err.response?.status === 401 || err.response?.status === 403) {
+          dispatch(logout());
+        }
+      }
+      return rejectWithValue("Failed to fetch supports");
+    }
+  }
+);
+
+export const patchSupport = createAsyncThunk<
+  Support,
+  { id: number; answer?: string; status?: SupportStatus },
+  { rejectValue: string; state: RootState }
+>(
+  "admin/support/patch",
+  async ({ id, answer, status }, { dispatch, rejectWithValue, getState }) => {
+    try {
+      const token = getState().auth.accessToken;
+      const res = await axios.patch(
+        `${process.env.NEXT_PUBLIC_API_URL}/v1/admin/support/${id}`,
+        { answer, status },
+        { headers: { Authorization: `Bearer ${token}` }, withCredentials: true }
+      );
+      return res.data as Support;
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        if (err.response?.status === 401 || err.response?.status === 403) {
+          dispatch(logout());
+        }
+      }
+      return rejectWithValue("Failed to update support");
+    }
+  }
+);

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -6,6 +6,7 @@ import { hotspringApi } from "../hotspring/hotspringApi";
 import adminUserReducer from "../admin/user/adminUserSlice";
 import lodgeReducer from "../admin/lodge/lodgeSlice";
 import reportsReducer from "../admin/reports/reportsSlice";
+import adminSupportReducer from "../admin/support/supportSlice";
 import { lodgeApi } from "../lodge/lodgeApi";
 import { priceApi } from "../price/priceApi";
 import reservationReducer from "../reservation/reservationSlice";
@@ -26,6 +27,7 @@ import newsSliceReducer from "../admin/news/newsSlice";
 import eventsSliceReducer from "../admin/events/eventsSlice";
 import { newsApi } from "../news/newsApi";
 import { eventsApi } from "../events/eventsApi";
+import { supportApi } from "../support/supportApi";
 
 export const store = configureStore({
   reducer: {
@@ -38,9 +40,10 @@ export const store = configureStore({
     "admin/reports": reportsReducer,
     "admin/ticketReports": reportsTicketReducer,
     "admin/news": newsSliceReducer,
-    "admin/events" : eventsSliceReducer,
-    adminReservation : adminReservationReducer,
-    adminTicketReservation : adminTicketReservationReducer,
+    "admin/events": eventsSliceReducer,
+    "admin/support": adminSupportReducer,
+    adminReservation: adminReservationReducer,
+    adminTicketReservation: adminTicketReservationReducer,
     [lodgeApi.reducerPath]: lodgeApi.reducer,
     [priceApi.reducerPath]: priceApi.reducer,
     reservation: reservationReducer,
@@ -56,6 +59,7 @@ export const store = configureStore({
     [reportTicketReviewApi.reducerPath]: reportTicketReviewApi.reducer,
     [newsApi.reducerPath]: newsApi.reducer,
     [eventsApi.reducerPath]: eventsApi.reducer,
+    [supportApi.reducerPath]: supportApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(
@@ -72,7 +76,8 @@ export const store = configureStore({
       ticketReviewApi.middleware,
       reportTicketReviewApi.middleware,
       newsApi.middleware,
-      eventsApi.middleware
+      eventsApi.middleware,
+      supportApi.middleware
     ),
 });
 

--- a/src/lib/support/supportApi.ts
+++ b/src/lib/support/supportApi.ts
@@ -1,0 +1,54 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { prepareAuthHeaders } from "@/utils/prepareAuthHeaders";
+import { Support } from "@/types/support";
+
+export interface GetMySupportsResponse {
+  items: Support[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export const supportApi = createApi({
+  reducerPath: "supportApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: `${process.env.NEXT_PUBLIC_API_URL}/v1`,
+    credentials: "include",
+    prepareHeaders: prepareAuthHeaders,
+  }),
+  tagTypes: ["Supports", "SupportDetail"],
+  endpoints: (builder) => ({
+    getMySupports: builder.query<
+      GetMySupportsResponse,
+      { page?: number; pageSize?: number } | void
+    >({
+      query: (args) => {
+        const page = args?.page ?? 1;
+        const pageSize = args?.pageSize ?? 10;
+        return `support/my?page=${page}&pageSize=${pageSize}`;
+      },
+      providesTags: ["Supports"],
+    }),
+    getSupportById: builder.query<Support, number>({
+      query: (id) => `support/${id}`,
+      providesTags: (_r, _e, id) => [{ type: "SupportDetail", id }],
+    }),
+    createSupport: builder.mutation<
+      Support,
+      { name: string; question: string }
+    >({
+      query: (body) => ({
+        url: `support`,
+        method: "POST",
+        body,
+      }),
+      invalidatesTags: ["Supports"],
+    }),
+  }),
+});
+
+export const {
+  useGetMySupportsQuery,
+  useGetSupportByIdQuery,
+  useCreateSupportMutation,
+} = supportApi;

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -1,0 +1,20 @@
+export type SupportStatus = "PENDING" | "ANSWERED";
+
+export interface Support {
+  id: number;
+  userId: number;
+  name: string;
+  question: string;
+  answer?: string | null;
+  status: SupportStatus;
+  createdAt: string;
+  updatedAt: string;
+  answeredAt?: string | null;
+}
+
+export interface SupportPagination {
+  data: Support[];
+  total: number;
+  page: number;
+  limit: number;
+}


### PR DESCRIPTION
# Pull Request

## Description  
- User-side RTK Query API: supportApi.ts
  - useGetMySupportsQuery (paginated “My inquiries” list)
  - useGetSupportByIdQuery (inquiry detail)
  - useCreateSupportMutation (create inquiry)
- Admin-side Thunk & Slice:
  - admin/support/supportThunk.ts – fetchAllSupports, patchSupport
  - admin/support/supportSlice.ts – list/pagination/update state management
- User pages:
  - Refactor app/[locale]/help/support/page.tsx (ContactListPage) to use RTK Query, login redirect on 401, modal for creating inquiries (Title + Question).
  - Add app/[locale]/help/contact/[id]/page.tsx (Contact Detail) showing Q/A with line breaks preserved (whitespace-pre-wrap) and 401 redirect.
- Admin pages:
  - Add app/[locale]/admin/support/page.tsx – paginated list with status badges and dates.
  - Add app/[locale]/admin/support/[id]/page.tsx – detail view with editable Answer and Status (Pending/Answered).
- Title vs Name: UI uses title as the inquiry heading; list/detail render title ?? name to support current backend field naming.

## Why  
- Enable users to submit inquiries and review answers (list + detail) with a clean data flow using RTK Query.
- Provide admins with an efficient workflow to browse all inquiries and update answers/status via thunks.
- Standardize data handling and UX (login redirect on unauthorized, consistent pagination, preserved formatting).

## Testing  
1. User flow
  - Login → visit /{locale}/help/support.
  - Click “New inquiry”, submit Title + Question → success toast → list refresh shows new item.
  - Click a list item → /{locale}/help/contact/[id] detail.
  - Verify Q/A renders with preserved line breaks.
  - Logout and revisit pages → toast + redirect to login (with next param).
2. Admin flow
  - Admin login → visit /{locale}/admin/support.
  - Verify pagination, status badges (Pending/Answered), Created/Answered dates.
  - Click a row → /{locale}/admin/support/[id].
  - Edit Answer and change Status → Save → redirected to list with updated row.
3. i18n
  - Confirm strings come from contact.json keys (contact.*, support.*, common.cancel, loading).
4. Type compatibility
  - Lists/detail render title ?? name. If backend later switches to title (or Prisma @map("name")), UI remains compatible.

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [x] Component or util func created  
- [x] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
