### PR TITLE
Feat/support

### DIFF
--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -4,5 +4,12 @@
   "logoutButton": "Logout",
   "adminButton": "Go to Admin",
   "profileButton": "Go to Profile",
-  "greetingInline": "Hello, {{nickname}}"
+  "greetingInline": "Hello, {{nickname}}",
+  "home": "Home",
+  "profile": "Profile",
+  "account": "Account",
+  "favorites": "Favorites",
+  "reservations": "Reservations",
+  "reviews": "Reviews",
+  "settings": "Settings"
 }

--- a/public/locales/ko/header.json
+++ b/public/locales/ko/header.json
@@ -4,5 +4,12 @@
   "logoutButton": "로그아웃",
   "adminButton": "관리자 페이지로 이동",
   "profileButton": "프로필로 이동",
-  "greetingInline": "{{nickname}}님 안녕하세요"
+  "greetingInline": "{{nickname}}님 안녕하세요",
+  "home" : "홈으로 이동",
+  "profile": "프로필",
+  "account": "계정 설정",
+  "favorites": "즐겨찾기",
+  "reservations": "예약관리",
+  "reviews": "리뷰관리",
+  "settings": "설정"
 }

--- a/public/locales/ko/header.json
+++ b/public/locales/ko/header.json
@@ -5,11 +5,13 @@
   "adminButton": "관리자 페이지로 이동",
   "profileButton": "프로필로 이동",
   "greetingInline": "{{nickname}}님 안녕하세요",
-  "home" : "홈으로 이동",
+  "home": "홈으로 이동",
   "profile": "프로필",
   "account": "계정 설정",
   "favorites": "즐겨찾기",
   "reservations": "예약관리",
   "reviews": "리뷰관리",
-  "settings": "설정"
+  "settings": "설정",
+  "faq": "자주 묻는 질문",
+  "contact": "고객센터"
 }

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -183,6 +183,15 @@ const SideMenu: React.FC<SideMenuProps> = ({
             </div>
           )}
 
+          {user?.role === "ADMIN" && (
+            <button
+              onClick={() => handleNavigation("/admin")}
+              className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 transition"
+            >
+              관리자 페이지
+            </button>
+          )}
+
           <div className="pt-6 border-t border-gray-200">
             <button
               onClick={() => handleNavigation("/")}
@@ -192,16 +201,14 @@ const SideMenu: React.FC<SideMenuProps> = ({
               {t("home")}
             </button>
           </div>
-        </div>
 
-        {user && (
-          <>
-            <div className="rounded-xl border border-gray-200 overflow-hidden bg-[#FAFAFA]">
+          {user && (
+            <>
               <button
                 onClick={() => setProfileOpen((v) => !v)}
                 aria-expanded={profileOpen}
                 aria-controls="profile-submenu"
-                className="w-full flex items-center justify-between px-3 py-3 hover:bg-white transition text-sm"
+                className="pt-6 w-full flex items-center justify-between px-3 py-3 text-sm border-t border-gray-200 hover:bg-white transition"
               >
                 <span className="flex items-center gap-2 text-gray-800">
                   <User className="h-5 w-5 text-primary-800" />
@@ -259,18 +266,9 @@ const SideMenu: React.FC<SideMenuProps> = ({
                   {t("settings", { defaultValue: "Settings" })}
                 </button>
               </div>
-            </div>
-
-            {user.role === "ADMIN" && (
-              <button
-                onClick={() => handleNavigation("/admin")}
-                className="w-full bg-primary-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-primary-700 transition"
-              >
-                {t("adminPage")}
-              </button>
-            )}
-          </>
-        )}
+            </>
+          )}
+        </div>
 
         <div className="rounded-xl border border-gray-200 overflow-hidden bg-[#FAFAFA]">
           <button

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -119,7 +119,7 @@ const SideMenu: React.FC<SideMenuProps> = ({
         `}
         style={{ WebkitOverflowScrolling: "touch" }}
       >
-        <div className="flex items-center justify-between pb-4 border-b border-gray-200 shrink-0 pr-2">
+        <div className="flex items-center justify-between pb-2 border-b border-gray-200 shrink-0 pr-2">
           <h2 className="text-base font-semibold text-primary-900">Menu</h2>
           <button
             onClick={onClose}


### PR DESCRIPTION
# Pull Request

## Description  
- Refactored SideMenu UI:
  - Moved the Profile accordion section to appear directly below the Home button.
  - Updated styling to use border-t separators, making the menu look more like a clean list of buttons.
  - Simplified layout structure by consolidating Home, Profile, and Admin into the same section for consistency.
- Updated header.json in locale:
  - Added/modified translation keys for menu items (profile, account, favorites, reservations, reviews, settings, adminPage, etc.).
  - Ensured default values and keys match the new SideMenu UI structure.

## Why  
- Improves UX by making the SideMenu layout more intuitive and consistent with a button-list style.
- Keeps i18n translations up to date with the latest UI changes, preventing missing labels or fallback text.

## Testing  
- Ran the app locally and verified:
  - SideMenu opens and closes correctly.
  - Home button appears first, Profile accordion appears directly below.
  - Accordion expand/collapse works smoothly.
  - Admin button shows only for role=ADMIN.
  - Updated translations load correctly for multiple locales (e.g., en, ko).

## Linked Issues  
Fixes #227 

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
