### PR TITLE
Feat/support

### DIFF
--- a/src/app/[locale]/admin/support/[id]/page.tsx
+++ b/src/app/[locale]/admin/support/[id]/page.tsx
@@ -23,6 +23,7 @@ export default function AdminSupportDetailPage() {
   const [status, setStatus] = useState<"PENDING" | "ANSWERED">(
     itemFromList?.status ?? "PENDING"
   );
+  const [showOriginal, setShowOriginal] = useState(false);
 
   useEffect(() => {
     if (itemFromList) {
@@ -84,6 +85,11 @@ export default function AdminSupportDetailPage() {
   }
 
   const it = itemFromList!;
+  const questionForAdmin = it.questionKo ?? it.question;
+  const answerPreviewForUser =
+    it.originalLang === "EN"
+      ? it.answerEn || (answer ? "(저장 후 영어 번역이 생성됩니다)" : "-")
+      : answer || "-";
 
   return (
     <div className="max-w-3xl mx-auto p-6">
@@ -95,7 +101,23 @@ export default function AdminSupportDetailPage() {
       </button>
 
       <div className="flex items-start justify-between gap-4 mb-6">
-        <h1 className="text-2xl font-bold break-words">{title}</h1>
+        <div className="flex flex-col gap-2">
+          <h1 className="text-2xl font-bold break-words">{title}</h1>
+          {it.originalLang && (
+            <span
+              className={
+                "inline-flex w-fit text-xs px-2 py-1 rounded border " +
+                (it.originalLang === "EN"
+                  ? "bg-blue-50 text-blue-700 border-blue-200"
+                  : "bg-gray-50 text-gray-700 border-gray-200")
+              }
+              title="문의 원문 언어"
+            >
+              {it.originalLang === "EN" ? "영문 문의" : "국문 문의"}
+            </span>
+          )}
+        </div>
+
         <span
           className={
             "text-xs px-2 py-1 rounded border " +
@@ -118,10 +140,25 @@ export default function AdminSupportDetailPage() {
         <div className="text-sm text-gray-700">
           이메일: {it.user?.email ?? "-"}
         </div>
-        <div className="text-sm font-semibold text-primary-700 mb-2">Q</div>
-        <div className="prose whitespace-pre-wrap break-words">
-          {it.question}
+
+        <div className="flex items-center justify-between mt-3">
+          <div className="text-sm font-semibold text-primary-700">Q</div>
+          {it.questionKo && it.originalLang === "EN" && (
+            <button
+              className="text-xs text-gray-600 underline"
+              onClick={() => setShowOriginal((v) => !v)}
+            >
+              {showOriginal ? "번역본 보기" : "원문 보기"}
+            </button>
+          )}
         </div>
+
+        <div className="prose whitespace-pre-wrap break-words mt-1">
+          {showOriginal && it.originalLang === "EN"
+            ? it.question
+            : questionForAdmin}
+        </div>
+
         <div className="text-xs text-gray-400 mt-2">
           제출 일시: {new Date(it.createdAt).toLocaleString()}
         </div>
@@ -136,6 +173,21 @@ export default function AdminSupportDetailPage() {
           className="w-full border rounded-lg px-3 py-2"
           placeholder="답변 내용을 입력하세요..."
         />
+        <div className="mt-3 p-3 bg-gray-50 border rounded-lg">
+          <div className="text-xs font-semibold text-gray-600 mb-1">
+            사용자에게 보일 답변 미리보기
+            {it.originalLang === "EN" ? " (영문)" : " (국문)"}
+          </div>
+          <div className="text-sm whitespace-pre-wrap break-words">
+            {answerPreviewForUser}
+          </div>
+          {it.originalLang === "EN" && !it.answerEn && answer && (
+            <div className="text-[11px] text-gray-500 mt-1">
+              * 저장하면 영어 번역이 생성되어 사용자가 영어로 보게 됩니다.
+            </div>
+          )}
+        </div>
+
         <div className="flex items-center justify-between mt-3">
           <div className="flex items-center gap-2">
             <label className="text-sm text-gray-600">상태</label>

--- a/src/app/[locale]/help/contact/[id]/page.tsx
+++ b/src/app/[locale]/help/contact/[id]/page.tsx
@@ -8,18 +8,7 @@ import { useAppSelector } from "@/lib/store/hooks";
 import toast from "react-hot-toast";
 import { useGetSupportByIdQuery } from "@/lib/support/supportApi";
 import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-
-type Ticket = {
-  id: number;
-  title?: string;      
-  name?: string;       
-  question: string;
-  answer?: string | null;
-  status: "PENDING" | "ANSWERED";
-  createdAt: string;
-  updatedAt: string;
-  answeredAt?: string | null;
-};
+import { Support } from "@/types/support";
 
 export default function ContactDetailPage() {
   const { t } = useTranslation("contact");
@@ -43,12 +32,9 @@ export default function ContactDetailPage() {
     }
   }, [user, router, loginUrl, t]);
 
-  const {
-    data,
-    isLoading,
-    isFetching,
-    error,
-  } = useGetSupportByIdQuery(idNum, { skip: !user || Number.isNaN(idNum) });
+  const { data, isLoading, isFetching, error } = useGetSupportByIdQuery(idNum, {
+    skip: !user || Number.isNaN(idNum),
+  });
 
   useEffect(() => {
     const e = error as FetchBaseQueryError | undefined;
@@ -60,8 +46,13 @@ export default function ContactDetailPage() {
     }
   }, [error, router, loginUrl, t]);
 
-  const ticket = data as Ticket | undefined;
-  const title = ticket?.title || ticket?.name || t("support.detailTitle");
+  const contact = data as Support | undefined;
+  const title = contact?.name || t("support.detailTitle");
+
+  const answerForUser =
+    contact?.originalLang === "EN"
+      ? contact?.answerEn ?? contact?.answer ?? ""
+      : contact?.answer ?? "";
 
   return (
     <div className="max-w-3xl mx-auto py-10 px-4">
@@ -74,7 +65,7 @@ export default function ContactDetailPage() {
 
       {isLoading || isFetching ? (
         <div className="text-gray-600">{t("loading")}</div>
-      ) : !ticket ? (
+      ) : !contact ? (
         <div className="text-gray-600">{t("support.notFound")}</div>
       ) : (
         <div className="space-y-6">
@@ -83,37 +74,37 @@ export default function ContactDetailPage() {
             <span
               className={
                 "text-xs px-2 py-1 rounded border shrink-0 " +
-                (ticket.status === "ANSWERED"
+                (contact.status === "ANSWERED"
                   ? "bg-green-50 text-green-700 border-green-200"
                   : "bg-amber-50 text-amber-700 border-amber-200")
               }
             >
-              {t(`support.status.${ticket.status.toLowerCase()}`)}
+              {t(`support.status.${contact.status.toLowerCase()}`)}
             </span>
           </div>
 
           <section className="rounded-xl border p-4">
             <div className="text-sm font-semibold text-primary-700 mb-2">Q</div>
             <div className="prose whitespace-pre-wrap break-words">
-              {ticket.question}
+              {contact.question}
             </div>
             <div className="text-xs text-gray-400 mt-2">
               {t("support.submittedAt")}:{" "}
-              {new Date(ticket.createdAt).toLocaleString()}
+              {new Date(contact.createdAt).toLocaleString()}
             </div>
           </section>
 
           <section className="rounded-xl border p-4">
             <div className="text-sm font-semibold text-gray-500 mb-2">A</div>
-            {ticket.answer ? (
+            {answerForUser ? (
               <>
                 <div className="prose whitespace-pre-wrap break-words">
-                  {ticket.answer}
+                  {answerForUser}
                 </div>
                 <div className="text-xs text-gray-400 mt-2">
                   {t("support.answeredAt")}:{" "}
-                  {ticket.answeredAt
-                    ? new Date(ticket.answeredAt).toLocaleString()
+                  {contact.answeredAt
+                    ? new Date(contact.answeredAt).toLocaleString()
                     : "-"}
                 </div>
               </>

--- a/src/app/[locale]/help/contact/page.tsx
+++ b/src/app/[locale]/help/contact/page.tsx
@@ -11,17 +11,7 @@ import {
   useCreateSupportMutation,
 } from "@/lib/support/supportApi";
 import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-
-type SupportItem = {
-  id: number;
-  name: string;
-  question: string;
-  answer?: string | null;
-  status: "PENDING" | "ANSWERED";
-  createdAt: string;
-  updatedAt: string;
-  answeredAt?: string | null;
-};
+import { Support } from "@/types/support";
 
 const ContactListPage = () => {
   const { t } = useTranslation("contact");
@@ -34,7 +24,7 @@ const ContactListPage = () => {
 
   const redirected = useRef(false);
   const loginUrl = `/${locale}/login?next=${encodeURIComponent(
-    `/${locale}/help/support`
+    `/${locale}/help/contact`
   )}`;
 
   useEffect(() => {
@@ -60,7 +50,7 @@ const ContactListPage = () => {
     }
   }, [error, router, loginUrl, t]);
 
-  const list = (data?.items ?? []) as SupportItem[];
+  const list = (data?.items ?? []) as Support[];
 
   const [createSupport, { isLoading: creating }] = useCreateSupportMutation();
 
@@ -109,39 +99,46 @@ const ContactListPage = () => {
         <div className="text-gray-600">{t("support.empty")}</div>
       ) : (
         <ul className="divide-y rounded-lg border">
-          {list.map((it) => (
-            <li
-              key={it.id}
-              className="p-4 cursor-pointer hover:bg-gray-50"
-              onClick={() => router.push(`/${locale}/help/contact/${it.id}`)}
-            >
-              <div className="flex items-center justify-between gap-3">
-                <div className="font-medium line-clamp-1">{it.name}</div>
-                <span
-                  className={
-                    "text-xs px-2 py-1 rounded border shrink-0 " +
-                    (it.status === "ANSWERED"
-                      ? "bg-green-50 text-green-700 border-green-200"
-                      : "bg-amber-50 text-amber-700 border-amber-200")
-                  }
-                >
-                  {t(`support.status.${it.status.toLowerCase()}`)}
-                </span>
-              </div>
-              <div className="text-xs text-gray-500 mt-1">
-                {new Date(it.createdAt).toLocaleString()}
-              </div>
-              {it.answer ? (
-                <div className="text-sm text-gray-700 mt-2 line-clamp-2">
-                  {t("support.answerPreview")} {it.answer}
+          {list.map((it) => {
+            const answerForUser =
+              it.originalLang === "EN"
+                ? it.answerEn ?? it.answer ?? ""
+                : it.answer ?? "";
+
+            return (
+              <li
+                key={it.id}
+                className="p-4 cursor-pointer hover:bg-gray-50"
+                onClick={() => router.push(`/${locale}/help/contact/${it.id}`)}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="font-medium line-clamp-1">{it.name}</div>
+                  <span
+                    className={
+                      "text-xs px-2 py-1 rounded border shrink-0 " +
+                      (it.status === "ANSWERED"
+                        ? "bg-green-50 text-green-700 border-green-200"
+                        : "bg-amber-50 text-amber-700 border-amber-200")
+                    }
+                  >
+                    {t(`support.status.${it.status.toLowerCase()}`)}
+                  </span>
                 </div>
-              ) : (
-                <div className="text-sm text-gray-500 mt-2">
-                  {t("support.waitingForAnswer")}
+                <div className="text-xs text-gray-500 mt-1">
+                  {new Date(it.createdAt).toLocaleString()}
                 </div>
-              )}
-            </li>
-          ))}
+                {answerForUser ? (
+                  <div className="text-sm text-gray-700 mt-2 line-clamp-2">
+                    {t("support.answerPreview")} {answerForUser}
+                  </div>
+                ) : (
+                  <div className="text-sm text-gray-500 mt-2">
+                    {t("support.waitingForAnswer")}
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -5,7 +5,10 @@ export interface Support {
   userId: number;
   name: string;
   question: string;
+  questionKo?: string | null;
+  originalLang?: string | null;
   answer?: string | null;
+  answerEn?: string | null;
   status: SupportStatus;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
# Pull Request

## Description  
- Updated Support type definition to include new answerEn field.
- Modified backend and frontend logic to handle answerEn alongside existing answer.
- Updated Support/Contact page and Contact detail page in the frontend to display and manage answerEn.

## Why  
Previously, only the default answer field was available for inquiries, limiting multi-language support.
By adding answerEn, admins can provide and manage English answers separately, enabling better communication for international users and improving usability of the contact system.

## Testing  
- Ran the app locally.
- Verified that Support type now includes answerEn.
- Confirmed that answerEn can be updated through the admin detail page.
- Checked that both Contact page and Contact detail page render the answerEn field correctly.
- Ensured existing support answer functionality (answer) still works without regression.

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
