### PR TITLE
Fix/news and events

### DIFF
--- a/public/locales/en/events-detail.json
+++ b/public/locales/en/events-detail.json
@@ -1,4 +1,6 @@
 {
-    "backToList": "Back to List",
-    "eventNotFound": "Event not found."
+  "backToList": "Back to List",
+  "eventNotFound": "Event not found.",
+  "nextArticle": "Next",
+  "prevArticle": "Prev"
 }

--- a/public/locales/en/news-detail.json
+++ b/public/locales/en/news-detail.json
@@ -1,4 +1,6 @@
 {
   "backToList": "Back to List",
-  "newsNotFound": "News not found."
+  "newsNotFound": "News not found.",
+  "nextArticle": "Next",
+  "prevArticle": "Prev"
 }

--- a/public/locales/ko/events-detail.json
+++ b/public/locales/ko/events-detail.json
@@ -1,4 +1,6 @@
 {
-    "backToList": "목록으로 돌아가기",
-    "eventNotFound": "이벤트를 찾을 수 없습니다."
+  "backToList": "목록으로 돌아가기",
+  "eventNotFound": "이벤트를 찾을 수 없습니다.",
+  "nextArticle": "다음글",
+  "prevArticle": "이전글"
 }

--- a/public/locales/ko/news-detail.json
+++ b/public/locales/ko/news-detail.json
@@ -1,4 +1,6 @@
 {
   "backToList": "목록으로 돌아가기",
-  "newsNotFound": "뉴스를 찾을 수 없습니다."
+  "newsNotFound": "뉴스를 찾을 수 없습니다.",
+  "nextArticle": "다음글",
+  "prevArticle": "이전글"
 }

--- a/src/app/[locale]/events/[id]/page.tsx
+++ b/src/app/[locale]/events/[id]/page.tsx
@@ -3,7 +3,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useLocale } from "@/utils/useLocale";
-import { useGetEventByIdQuery } from "@/lib/events/eventsApi";
+import {
+  useGetAdjacentEventByIdQuery,
+  useGetEventByIdQuery,
+} from "@/lib/events/eventsApi";
 import { useParams, useRouter } from "next/navigation";
 import HTMLViewer from "@/components/HTMLViewer";
 import { getLocalizedField } from "@/utils/getLocalizedField";
@@ -26,8 +29,18 @@ const EventDetailPage = () => {
   const locale = useLocale();
   const router = useRouter();
   const { id } = useParams();
+  const eventId = Number(id);
 
   const { data: event, isLoading, isError } = useGetEventByIdQuery(Number(id));
+
+  const { data: adjacent } = useGetAdjacentEventByIdQuery(eventId, {
+    skip: !eventId || isLoading || isError,
+  });
+
+  const go = (targetId?: number | null) => {
+    if (!targetId) return;
+    router.push(`/${locale}/events/${targetId}`);
+  };
 
   const titleToShow = getLocalizedField(event?.title, event?.titleEn, locale);
   const contentToShow = getLocalizedField(
@@ -116,6 +129,40 @@ const EventDetailPage = () => {
             "
           >
             <HTMLViewer html={contentToShow} />
+          </div>
+
+          <div className="mt-10 border-t border-gray-200 pt-6 text-sm sm:text-base">
+            {adjacent?.next && (
+              <div
+                onClick={() => go(adjacent.next?.id)}
+                className="cursor-pointer hover:underline mb-4"
+              >
+                <strong>{t("nextArticle") ?? "다음글"}</strong>
+                <div className="text-gray-700">
+                  {getLocalizedField(
+                    adjacent.next.title,
+                    adjacent.next.titleEn,
+                    locale
+                  )}
+                </div>
+              </div>
+            )}
+
+            {adjacent?.prev && (
+              <div
+                onClick={() => go(adjacent.prev?.id)}
+                className="cursor-pointer hover:underline"
+              >
+                <strong>{t("prevArticle") ?? "이전글"}</strong>
+                <div className="text-gray-700">
+                  {getLocalizedField(
+                    adjacent.prev.title,
+                    adjacent.prev.titleEn,
+                    locale
+                  )}
+                </div>
+              </div>
+            )}
           </div>
         </article>
       )}

--- a/src/app/[locale]/news/[id]/page.tsx
+++ b/src/app/[locale]/news/[id]/page.tsx
@@ -3,7 +3,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useLocale } from "@/utils/useLocale";
-import { useGetNewsByIdQuery } from "@/lib/news/newsApi";
+import {
+  useGetAdjacentNewsByIdQuery,
+  useGetNewsByIdQuery,
+} from "@/lib/news/newsApi";
 import { useParams, useRouter } from "next/navigation";
 import HTMLViewer from "@/components/HTMLViewer";
 import { getLocalizedField } from "@/utils/getLocalizedField";
@@ -26,8 +29,18 @@ const NewsDetailPage = () => {
   const locale = useLocale();
   const router = useRouter();
   const { id } = useParams();
+  const newsId = Number(id);
 
   const { data: news, isLoading, isError } = useGetNewsByIdQuery(Number(id));
+
+  const { data: adjacent } = useGetAdjacentNewsByIdQuery(newsId, {
+    skip: !newsId || isLoading || isError,
+  });
+
+  const go = (targetId?: number | null) => {
+    if (!targetId) return;
+    router.push(`/${locale}/news/${targetId}`);
+  };
 
   const titleToShow = getLocalizedField(news?.title, news?.titleEn, locale);
   const contentToShow = getLocalizedField(
@@ -116,6 +129,40 @@ const NewsDetailPage = () => {
             "
           >
             <HTMLViewer html={contentToShow} />
+          </div>
+
+          <div className="mt-10 border-t border-gray-200 pt-6 text-sm sm:text-base">
+            {adjacent?.next && (
+              <div
+                onClick={() => go(adjacent.next?.id)}
+                className="cursor-pointer hover:underline mb-4"
+              >
+                <strong>{t("nextArticle") ?? "다음글"}</strong>
+                <div className="text-gray-700">
+                  {getLocalizedField(
+                    adjacent.next.title,
+                    adjacent.next.titleEn,
+                    locale
+                  )}
+                </div>
+              </div>
+            )}
+
+            {adjacent?.prev && (
+              <div
+                onClick={() => go(adjacent.prev?.id)}
+                className="cursor-pointer hover:underline"
+              >
+                <strong>{t("prevArticle") ?? "이전글"}</strong>
+                <div className="text-gray-700">
+                  {getLocalizedField(
+                    adjacent.prev.title,
+                    adjacent.prev.titleEn,
+                    locale
+                  )}
+                </div>
+              </div>
+            )}
           </div>
         </article>
       )}

--- a/src/lib/events/eventsApi.ts
+++ b/src/lib/events/eventsApi.ts
@@ -8,6 +8,11 @@ interface GetEventListResponse {
   limit: number;
 }
 
+interface AdjacentRes {
+  prev: Pick<Event, "id" | "title" | "titleEn" | "createdAt"> | null;
+  next: Pick<Event, "id" | "title" | "titleEn" | "createdAt"> | null;
+}
+
 export const eventsApi = createApi({
   reducerPath: "eventsApi",
   baseQuery: fetchBaseQuery({
@@ -16,7 +21,10 @@ export const eventsApi = createApi({
   }),
   tagTypes: ["Events"],
   endpoints: (builder) => ({
-    getAllEvents: builder.query<GetEventListResponse, { page?: number; limit?: number }>({
+    getAllEvents: builder.query<
+      GetEventListResponse,
+      { page?: number; limit?: number }
+    >({
       query: ({ page = 1, limit = 10 }) => `?page=${page}&limit=${limit}`,
       providesTags: ["Events"],
     }),
@@ -24,7 +32,15 @@ export const eventsApi = createApi({
       query: (id) => `/${id}`,
       providesTags: (result, error, id) => [{ type: "Events", id }],
     }),
+    getAdjacentEventById: builder.query<AdjacentRes, number>({
+      query: (id) => `/${id}/adjacent`,
+      providesTags: (result, error, id) => [{ type: "Events", id }],
+    }),
   }),
 });
 
-export const { useGetAllEventsQuery, useGetEventByIdQuery } = eventsApi;
+export const {
+  useGetAllEventsQuery,
+  useGetEventByIdQuery,
+  useGetAdjacentEventByIdQuery,
+} = eventsApi;

--- a/src/lib/news/newsApi.ts
+++ b/src/lib/news/newsApi.ts
@@ -8,6 +8,11 @@ interface GetNewsListResponse {
   limit: number;
 }
 
+interface AdjacentRes {
+  prev: Pick<News, "id" | "title" | "titleEn" | "createdAt"> | null;
+  next: Pick<News, "id" | "title" | "titleEn" | "createdAt"> | null;
+}
+
 export const newsApi = createApi({
   reducerPath: "newsApi",
   baseQuery: fetchBaseQuery({
@@ -27,7 +32,15 @@ export const newsApi = createApi({
       query: (id) => `/${id}`,
       providesTags: (result, error, id) => [{ type: "News", id }],
     }),
+    getAdjacentNewsById: builder.query<AdjacentRes, number>({
+      query: (id) => `/${id}/adjacent`,
+      providesTags: (result, error, id) => [{ type: "News", id }],
+    }),
   }),
 });
 
-export const { useGetAllNewsQuery, useGetNewsByIdQuery } = newsApi;
+export const {
+  useGetAllNewsQuery,
+  useGetNewsByIdQuery,
+  useGetAdjacentNewsByIdQuery,
+} = newsApi;


### PR DESCRIPTION
# Pull Request

## Description  
- Backend/RTK Query
  - Added getAdjacentNewsById endpoint in newsApi.ts to fetch previous and next news metadata (id, title, createdAt).
  - Added getAdjacentEventById endpoint in eventsApi.ts to fetch previous and next event metadata.
- Frontend UI
  - Updated NewsDetailPage:
    - Added Prev/Next article section at the bottom.
    - Shows the adjacent article’s title with routing by id.
  - Updated EventDetailPage:
    - Added Prev/Next event section at the bottom.
    - Shows adjacent event’s title with routing by id.

## Why  
- Improves user navigation by allowing readers to quickly move between related news and event articles.
- Enhances UX by displaying adjacent article/event titles directly within the detail page.
- Keeps frontend and backend consistent by supporting adjacent queries for both news and events.

## Testing  
- Ran app locally.
- Verified /v1/news/:id/adjacent and /v1/events/:id/adjacent return correct prev and next data.
- Confirmed useGetAdjacentNewsByIdQuery and useGetAdjacentEventByIdQuery work in frontend.
- Checked NewsDetailPage and EventDetailPage render prev/next sections correctly.
- Verified clicking titles routes to the correct article/event detail page via id.

## Linked Issues  
None

## Checklist  
<!-- 
Mark completed items with an [x]  
-->
- [x] Code builds and runs locally  
- [ ] Component or util func created  
- [ ] Page layout added  
- [x] Tests (if any) pass  
- [ ] I have reviewed my code for clarity and best practices  
